### PR TITLE
Remove quotes from the port setting

### DIFF
--- a/kube/deployment.yml
+++ b/kube/deployment.yml
@@ -35,7 +35,7 @@ spec:
             memory: 500Mi
         ports:
           - name: frontend
-            containerPort: "{{.SGMR_SERVICE_PORT}}"
+            containerPort: {{.SGMR_SERVICE_PORT}}
         env:
           - name: SGMR_DATA_API_BASE_URL
             value: {{.SGMR_DATA_API_BASE_URL}}


### PR DESCRIPTION
Removes the quotes from the port line, making it an integer as expected