### PR TITLE
Cg 121 exit cancel

### DIFF
--- a/src/components/SectionTabs.jsx
+++ b/src/components/SectionTabs.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 
 // App imports
-import { getData, postData } from '@utils/apiHooks';
+import { getData, patchData, postData } from '@utils/apiHooks';
 import { formatUIDate } from '@utils/date';
 import { USER_VOYAGE_REPORT_URL } from '@constants/ApiConstants';
 import { EDIT_VOYAGE_CHECK_DETAILS_URL } from '@constants/ClientConstants';
@@ -30,6 +30,7 @@ const SectionTabs = (pageData) => {
     },
   ];
 
+
   const setActiveTab = (e) => {
     const tabArray = [...tabData];
     tabArray.map((elem) => {
@@ -43,14 +44,27 @@ const SectionTabs = (pageData) => {
     setTabData(tabArray);
   };
 
+
+  const removeAnyInvalidReports = (reports) => {
+    let validReports = [];
+    reports.map((report) => {
+      if (report.departureDate) {
+        validReports.push(report);
+      }
+    });
+    setReportList(validReports);
+  };
+
+
   const getReportList = () => {
     getData(USER_VOYAGE_REPORT_URL)
       .then((resp) => {
         if (!resp.errors) {
-          setReportList(resp.items);
+          removeAnyInvalidReports(resp.items);
         }
       });
   };
+
 
   const handleStart = () => {
     postData(USER_VOYAGE_REPORT_URL, null, 'reports')
@@ -61,6 +75,7 @@ const SectionTabs = (pageData) => {
         });
       });
   };
+
 
   useEffect(() => {
     setTabData(tabs);

--- a/src/components/Voyage/FormArrival.jsx
+++ b/src/components/Voyage/FormArrival.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const FormArrival = ({
-  handleSubmit, handleChange, data, errors, voyageId
+  handleSubmit, handleChange, data, errors, voyageId,
 }) => {
   if (!data) { return (null); }
   return (

--- a/src/components/Voyage/FormCheck.jsx
+++ b/src/components/Voyage/FormCheck.jsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import { formatUIDate } from '@utils/date';
 import PeopleManifest from '@components/Voyage/PeopleManifest';
 
-const FormCheck = ({ voyageId, voyageData }) => {
+const FormCheck = ({ voyageId, voyageData, handleSubmit }) => {
   if (!voyageData) { return null; }
   return (
     <section>
@@ -221,7 +221,7 @@ const FormCheck = ({ voyageId, voyageData }) => {
         type="button"
         className="govuk-button govuk-button--warning govuk-body govuk!-margin-top-3 block-button"
         data-module="govuk-button"
-
+        onClick={((e) => handleSubmit(e, 'cancel'))}
       >
         Cancel voyage
       </button>

--- a/src/components/Voyage/VoyageFormContainer.jsx
+++ b/src/components/Voyage/VoyageFormContainer.jsx
@@ -152,15 +152,19 @@ const FormVoyageContainer = () => {
   };
 
 
-  const setNextPage = () => {
+  const setNextPage = (sourceForm) => {
     let nextPage;
-    if (pageNum === '4b') {
-      nextPage = 4;
-    } else {
-      nextPage = pageNum < maxPages ? pageNum + 1 : pageNum;
+    switch (sourceForm) {
+      case 'cancel': history.push('/reports'); break;
+      case 'submit': history.push('/save-voyage/submitted'); break;
+      default: if (pageNum === '4b') {
+        nextPage = 4;
+      } else {
+        nextPage = pageNum < maxPages ? pageNum + 1 : pageNum;
+      }
+        setPageNum(nextPage);
+        history.push(`/save-voyage/page-${nextPage}`, { voyageId });
     }
-    setPageNum(nextPage);
-    history.push(`/save-voyage/page-${nextPage}`, { voyageId });
   };
 
 
@@ -173,6 +177,8 @@ const FormVoyageContainer = () => {
       case 'people': dataToSubmit = formatPerson('Draft', formData, voyageData); break;
       case 'responsiblePerson': dataToSubmit = formatResponsiblePerson('Draft', formData, voyageData); break;
       case 'vessel': dataToSubmit = formatVessel('Draft', formData, voyageData); break;
+      case 'voyage': dataToSubmit = { status: 'PreSubmitted' }; break;
+      case 'cancel': dataToSubmit = { status: 'PreCancelled' }; break;
       default: dataToSubmit = null;
     }
 
@@ -185,7 +191,7 @@ const FormVoyageContainer = () => {
       if (Object.keys(VoyageFormValidation(formData, sourceForm)).length === 0 && Object.keys(errors).length === 0) {
         patchData(`${VOYAGE_REPORT_URL}/${voyageId}`, dataToSubmit, location.pathname.substring(1))
           .then(() => {
-            setNextPage();
+            setNextPage(sourceForm);
           });
       }
     }
@@ -316,6 +322,7 @@ const FormVoyageContainer = () => {
                 <FormCheck
                   voyageId={voyageId}
                   voyageData={voyageData}
+                  handleSubmit={handleSubmit}
                 />
               )}
             </form>

--- a/src/components/Voyage/VoyageFormContainer.jsx
+++ b/src/components/Voyage/VoyageFormContainer.jsx
@@ -319,6 +319,7 @@ const FormVoyageContainer = () => {
                 />
               )}
             </form>
+            <p><Link to="/reports" className="govuk-link govuk-link--no-visited-state">Exit without saving</Link></p>
           </div>
         </div>
       </main>


### PR DESCRIPTION
**EXIT WITHOUT SAVING**
- Exit without saving option on all form voyage page

TEST
- On click returns you to /reports without changes being saved
- NOTE: manifest will already be saved

——

**CANCEL DRAFT VOYAGE**
- Cancel button on check page

TEST
- On click returns you to /reports
- Your voyage should be listed under the cancelled tab

----
**HIDE INVALID REPORTS**
- if report has an invalid departureDate (aka user clicked 'save voyage' button but did not progress past page 1 save and continue, hide those from the report page

TEST
- click on save voyage
- click on /reports
> You should not see any Invalid Date reports

NOTE: This PR does not send any status update or delete request to the API to remove these