### PR TITLE
COP-2510: Add Privacy and Cookie Policy page

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -7,6 +7,18 @@ const Footer = () => {
       <div className="govuk-width-container ">
         <div className="govuk-footer__meta">
           <div className="govuk-footer__meta-item govuk-footer__meta-item--grow">
+            <h2 className="govuk-visually-hidden">Support links</h2>
+            <ul className="govuk-footer__inline-list">
+              <li className="govuk-footer__inline-list-item"><a className="govuk-footer__link" href="/privacy-and-cookie-policy">Privacy and Cookie Policy</a></li>
+              <li className="govuk-footer__inline-list-item"><a className="govuk-footer__link" href="/accessibility-statement">Accessibility Statement</a></li>
+              <li className="govuk-footer__inline-list-item">
+                <a className="govuk-footer__link" href="#" target="_blank" rel="noopener noreferrer">
+                  Help
+                </a>
+              </li>
+            </ul>
+          </div>
+          <div className="govuk-footer__meta-item">
             <Link
               className="govuk-footer__link govuk-footer__copyright-logo"
               to="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -12,7 +12,7 @@ const Footer = () => {
               <li className="govuk-footer__inline-list-item"><a className="govuk-footer__link" href="/privacy-and-cookie-policy">Privacy and Cookie Policy</a></li>
               <li className="govuk-footer__inline-list-item"><a className="govuk-footer__link" href="/accessibility-statement">Accessibility Statement</a></li>
               <li className="govuk-footer__inline-list-item">
-                <a className="govuk-footer__link" href="#" target="_blank" rel="noopener noreferrer">
+                <a className="govuk-footer__link" href="/help" target="_blank" rel="noopener noreferrer">
                   Help
                 </a>
               </li>

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -8,6 +8,7 @@ import SecureRoute from '@lib/SecureRoute';
 import Banner from '@components/Banner';
 import Footer from '@components/Footer';
 import Header from '@components/Header';
+import PrivacyCookiePolicy from '@components/PrivacyCookiePolicy';
 import PageContainer from '@components/PageContainer';
 
 import CreateAPerson from '@components/People/CreateAPerson';
@@ -81,6 +82,9 @@ const Main = () => {
         </Route>
         <Route exact path="/resend-code">
           <UserResendCode />
+        </Route>
+        <Route exact path="/privacy-and-cookie-policy">
+          <PrivacyCookiePolicy />
         </Route>
       </Switch>
       </UserContext.Provider>

--- a/src/components/PrivacyCookiePolicy.jsx
+++ b/src/components/PrivacyCookiePolicy.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+const PrivacyCookiePolicy = () => {
+  return (
+    <div className="govuk-width-container ">
+      <main className="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+        <div className="govuk-grid-row">
+          <div className="govuk-width-container">
+            <h1 className="govuk-heading-l">Privacy notice for General Maritime (Pleasure Craft) Advanced Voyage Notification</h1>
+            <p className="govuk-body">
+              Provision of the Advance Voyage Notification service is from the borders, immigration and citizenship system, which is part of the Home Office. Please visit the guidance at
+              {' '}
+              <a href="https://www.gov.uk/government/publications/personal-information-use-in-borders-immigration-and-citizenship">Borders, immigration and citizenship: privacy information notice</a>
+              {' '}
+              for full information on how your personal information may be used within the Home Office Borders, Immigration and Citizenship System.
+            </p>
+            <h2 className="govuk-heading-m">What data we need</h2>
+            <p className="govuk-body">The personal data we collect from you on the Submit an Advance Voyage Notification service may include:</p>
+            <ul className="govuk-list govuk-list--bullet">
+              <li>your full name</li>
+              <li>other travel document information such as document number and expiry date</li>
+              <li>nationality information</li>
+              <li>information on who the person responsible for the voyage is</li>
+              <li>
+                information on how you use the site, using cookies and page tagging techniques:
+                <ul className="govuk-list govuk-list--bullet">
+                  <li>the pages you visit on Submit an Advance Voyage Report</li>
+                  <li>how long you spend on each page</li>
+                  <li>what you click on while you’re visiting the site</li>
+                </ul>
+              </li>
+            </ul>
+            <p className="govuk-body">
+              Under the Data Protection Act 2018, we are processing your personal information on a performance-of-a-public-task basis to allow Border Force to discharge our duties around your entry into the United Kingdom.
+              We may process your information in systems other that the Submit an Advance Voyage Notification Service. The legislative basis for collecting this information is the Immigration Act of 1971 Paragraph 27B.
+            </p>
+            <h2 className="govuk-heading-l">Cookies</h2>
+            <p className="govuk-body">This service puts small files (known as &apos;cookies&apos;) onto your computer to collect information about how you browse the site.</p>
+            <p className="govuk-body">Cookies are used to help identify you when you return to the site and improves the way you can access the site by storing your logon information for a limited period when you complete the General Maritime Advance Voyage Notification.</p>
+            <h2 className="govuk-heading-m">How cookies are used</h2>
+            <h3 className="govuk-heading-s">Measuring website usage</h3>
+            <p className="govuk-body">We use cookies to collect information as you interact with the Submit General Maritime Advance Voyage Notification. We do this to help make sure the site is meeting the needs of its users and to help us make improvements. Cookies will be used to monitor specific user information to improve your access to the form by remembering your non-personal details for the next time you submit a form. </p>
+            <h3 className="govuk-heading-s">Cookie Details</h3>
+            <p className="govuk-body">Submit an Advance Voyage Notification uses cookies. The two types of persistent cookies are:</p>
+            <ul className="govuk-list govuk-list--bullet">
+              <li>_pk_id: used to store a few details about you such as the unique visitor ID, stored for 13 months; and</li>
+              <li>_pk_ref: used to store information to initially identify you when you visit the website, stored for 6 months.</li>
+            </ul>
+            <p className="govuk-body">The two types of session cookies are:</p>
+            <ul className="govuk-list govuk-list--bullet">
+              <li>_pk_hsr (heatmap and session recording); and</li>
+              <li>_pk_ses: used to temporarily store data for the visit and are stored for 30 minutes.</li>
+            </ul>
+            <h2 className="govuk-heading-m">Cookie Introductory Message</h2>
+            <p className="govuk-body">You may see a Cookie Notice pop-up message when you first Submit an Advance Voyage Notification. This message is to advise you that the process will capture cookies as described above. By accessing the Advance Voyage Notification form, you are consenting to the use of cookies described above. </p>
+            <h2 className="govuk-heading-m">Why we need this data</h2>
+            <p className="govuk-body">We use cookie information to enable you to log into the service that we provide and to link information you add into Submit an Advance Voyage Notification to your account.</p>
+            <p className="govuk-body">We use the information you provide to help ensure that we can enforce access control and keep data secure.</p>
+            <p className="govuk-body">We use information about your email and your name that we hold within the system when we send you a notification. We use the GOV.UK Notify service, to send you notifications from the service to your email address; the GOV.UK Notify service is operated and assured by the Cabinet Office. </p>
+            <p className="govuk-body">The legal basis for processing your personal data is for the performance of a public task . Privacy and Electronic Communications Regulations (PECR) require either the subscriber’s or the user’s consent. </p>
+            <p className="govuk-body">More information about the privacy of the system and the use of and how we store your data can be found on the Borders, immigration and citizenship: privacy information notice page. </p>
+            <p className="govuk-body">Under the Data Protection Act 2018 and General Data Protection Regulation you also have the right to object to and ask to restrict our use of your personal information, and to ask us to rectify or delete your personal information. However, there may be a number of legal or other official reasons why we need to continue to keep or use your data. </p>
+            <p className="govuk-body">
+              If you want to exercise these rights please email us at:
+              {' '}
+              <a href="mailto:subjectaccessrequest@homeoffice.gov.uk">subjectaccessrequest@homeoffice.gov.uk</a>
+            </p>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default PrivacyCookiePolicy;


### PR DESCRIPTION
## Description
This branch adds the Privacy and Cookie policy page to the service and updates the footer to include a link to this, and placeholder links fo the Accessibility statement / Help pages (these are to follow). 

## To test:
- clone and run the app. 
- navigate to the footer and click the Privacy and Cookie Policy link. 
- Content should display as defined by business (see ticket: https://support.cop.homeoffice.gov.uk/browse/COP-2510)

## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
