### PR TITLE
COP-3189: Update Voyage Check page

### DIFF
--- a/cypress/integration/sGMR/voyage-report-form-validation.spec.js
+++ b/cypress/integration/sGMR/voyage-report-form-validation.spec.js
@@ -116,8 +116,8 @@ describe('Validate report form', () => {
   });
   it('Should verify Skipper details mandatory data', () => {
     const errors = [
-      'You must enter a given name',
-      'You must enter a given name',
+      'You must enter a first name',
+      'You must enter a last name',
       'You must enter a contact number',
       'You must enter the first line of your address',
       'You must enter the second line of your address',

--- a/src/components/Forms/validationRules.js
+++ b/src/components/Forms/validationRules.js
@@ -96,13 +96,13 @@ export const responsiblePersonValidationRules = [
     inputField: 'responsibleGivenName',
     errorDisplayId: 'responsibleGivenName',
     rule: 'required',
-    message: 'You must enter a given name',
+    message: 'You must enter a first name',
   },
   {
     inputField: 'responsibleSurname',
     errorDisplayId: 'responsibleSurname',
     rule: 'required',
-    message: 'You must enter a given name',
+    message: 'You must enter a last name',
   },
   {
     inputField: 'responsibleContactNo',
@@ -340,6 +340,12 @@ export const voyageValidationRules = [
     errorDisplayId: 'arrivalDate',
     rule: 'required',
     message: 'You must enter an arrival date',
+  },
+  {
+    inputField: 'responsibleGivenName',
+    errorDisplayId: 'responsibleGivenName',
+    rule: 'required',
+    message: 'You must enter the responsible person\'s details',
   },
 ];
 

--- a/src/components/Voyage/FormCheck.jsx
+++ b/src/components/Voyage/FormCheck.jsx
@@ -187,13 +187,17 @@ const FormCheck = ({
           </dd>
         </div>
       </dl>
+
+      <div className="govuk-form-group govuk-form-group--error">
+        <p className="govuk-error-message">{errors.responsibleGivenName}</p>
+      </div>
       <dl className="govuk-summary-list govuk-!-margin-bottom-9">
         <div className="govuk-summary-list__row">
-          <dt className="govuk-summary-list__key">Given name</dt>
+          <dt className="govuk-summary-list__key">First name</dt>
           <dd className="govuk-summary-list__value">{voyageData.responsibleGivenName}</dd>
         </div>
         <div className="govuk-summary-list__row">
-          <dt className="govuk-summary-list__key">Surname</dt>
+          <dt className="govuk-summary-list__key">Last name</dt>
           <dd className="govuk-summary-list__value">{voyageData.responsibleSurname}</dd>
         </div>
         <div className="govuk-summary-list__row">

--- a/src/components/Voyage/__tests__/VoyageFormValidation.test.js
+++ b/src/components/Voyage/__tests__/VoyageFormValidation.test.js
@@ -7,9 +7,9 @@ test('Validates responsible person', () => {
     responsibleAddressLine2: 'You must enter the second line of your address',
     responsibleContactNo: 'You must enter a contact number',
     responsibleCounty: 'You must enter a country name',
-    responsibleGivenName: 'You must enter a given name',
+    responsibleGivenName: 'You must enter a first name',
     responsiblePostcode: 'You must enter a postcode',
-    responsibleSurname: 'You must enter a given name',
+    responsibleSurname: 'You must enter a last name',
     responsibleTown: 'You must enter a town or a city name',
   };
   const result = VoyageFormValidation({}, FORM_STEPS.RESPONSIBLE_PERSON);


### PR DESCRIPTION
## Description
This branch updates the last page of the voyage report form ("Check fields" page) so that a user cannot submit a voyage with no responsible person on board by making this field mandatory. Before this change, a user could save an incomplete voyage with no responsible person as a Draft, access it from the Drafts tab on dashboard page and submit it. This branch also updates the naming conventions from Given name to first name, surname to last name and fixed the tests. 

### To test:
- run project locally. Sign in and navigate to home page. 
- Start a new voyage report: fill in the details for pages 1-4 but do NOT save any Skipper details on http://localhost:8080/save-voyage/page-5. Click Exit without saving at the bottom. 
- This will take you back to the home page. You should see your incomplete voyage under the Drafts tab. Click on this and it takes you to the check page. Now if you try to submit the voyage it will show you an error "You must enter the responsible person's details". You can add these details by clicking the change button.

## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [x] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
