### PR TITLE
COP-3190 & COP-2758: Add mobile number validation and mark vessel fields as optional

### DIFF
--- a/src/components/Forms/validationRules.js
+++ b/src/components/Forms/validationRules.js
@@ -1,5 +1,6 @@
 export const VALID_EMAIL_REGEX = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
 export const COMPLEX_PASSWORD_REGEX = /(\d+)|([a-z]+)|([A-Z]+)|([!@$%^&\\(){}[\]:;<>,*.?/~_+-=|]+)+/g;
+export const VALID_MOBILE_REGEX = /^\d([ 0-9]{3,20})$/i;
 
 export const personValidationRules = [
   {

--- a/src/components/Forms/validationRules.js
+++ b/src/components/Forms/validationRules.js
@@ -1,6 +1,6 @@
 export const VALID_EMAIL_REGEX = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
 export const COMPLEX_PASSWORD_REGEX = /(\d+)|([a-z]+)|([A-Z]+)|([!@$%^&\\(){}[\]:;<>,*.?/~_+-=|]+)+/g;
-export const VALID_MOBILE_REGEX = /^\d([ 0-9]{3,20})$/i;
+export const VALID_MOBILE_REGEX = /^[0|+]([ 0-9]{3,20})$/i;
 
 export const personValidationRules = [
   {

--- a/src/components/User/UserRegister.jsx
+++ b/src/components/User/UserRegister.jsx
@@ -117,7 +117,7 @@ const UserRegister = () => {
                   Mobile number
                 </label>
                 <FormError error={errors.mobileNumber} />
-                <span className="govuk-hint">We will send an access code to this number</span>
+                <span className="govuk-hint">We will send an access code to this number. For international numbers include the country code.</span>
                 <input
                   id="mobileNumber-field"
                   className="govuk-input"
@@ -132,7 +132,7 @@ const UserRegister = () => {
                   Email address
                 </label>
                 <FormError error={errors.email} />
-                <span className="govuk-hint">You will use this to sign into your account</span>
+                <span className="govuk-hint">You will use this to sign into your account.</span>
                 <input
                   id="email-field"
                   className="govuk-input"

--- a/src/components/User/UserRegisterValidation.jsx
+++ b/src/components/User/UserRegisterValidation.jsx
@@ -2,6 +2,7 @@ import {
   passwordValidation,
   userValidationRules,
   VALID_EMAIL_REGEX,
+  VALID_MOBILE_REGEX,
 } from '@components/Forms/validationRules';
 import scrollToTopOnError from '@utils/scrollToTopOnError';
 
@@ -22,9 +23,10 @@ const UserRegisterValidation = (dataToValidate) => {
   }
 
   // Mobile Number field must be valid
-  if (!parseInt(dataToValidate.mobileNumber, 10)) {
+  if (!(VALID_MOBILE_REGEX.test(dataToValidate.mobileNumber))) {
     fieldsErroring.mobileNumber = 'You must enter a valid phone number';
   }
+
 
   // Password must be complex
   const passwordValidationError = passwordValidation(dataToValidate.password);

--- a/src/components/User/UserRegisterValidation.jsx
+++ b/src/components/User/UserRegisterValidation.jsx
@@ -24,7 +24,7 @@ const UserRegisterValidation = (dataToValidate) => {
 
   // Mobile Number field must be valid
   if (!(VALID_MOBILE_REGEX.test(dataToValidate.mobileNumber))) {
-    fieldsErroring.mobileNumber = 'You must enter a valid phone number e.g. 07700 900000, 0033 63998 010101 ';
+    fieldsErroring.mobileNumber = 'You must enter a valid phone number e.g. 07700 900982, +33 63998 010101';
   }
 
   // Password must be complex

--- a/src/components/User/UserRegisterValidation.jsx
+++ b/src/components/User/UserRegisterValidation.jsx
@@ -24,9 +24,8 @@ const UserRegisterValidation = (dataToValidate) => {
 
   // Mobile Number field must be valid
   if (!(VALID_MOBILE_REGEX.test(dataToValidate.mobileNumber))) {
-    fieldsErroring.mobileNumber = 'You must enter a valid phone number';
+    fieldsErroring.mobileNumber = 'You must enter a valid phone number e.g. 07700 900000, 0033 63998 010101 ';
   }
-
 
   // Password must be complex
   const passwordValidationError = passwordValidation(dataToValidate.password);

--- a/src/components/Vessel/FormVessel.jsx
+++ b/src/components/Vessel/FormVessel.jsx
@@ -67,7 +67,7 @@ const FormVessel = ({
 
       <div id="hullIdentificationNumber" className="govuk-form-group">
         <label className="govuk-label" htmlFor="hullIdentificationNumber">
-          Hull identification number
+          Hull identification number (optional)
         </label>
         <input
           className="govuk-input"
@@ -80,7 +80,7 @@ const FormVessel = ({
 
       <div id="callsign" className="govuk-form-group">
         <label className="govuk-label" htmlFor="callsign">
-          Callsign
+          Callsign (optional)
         </label>
         <input
           className="govuk-input"
@@ -93,7 +93,7 @@ const FormVessel = ({
 
       <div id="vesselNationality" className="govuk-form-group">
         <label className="govuk-label" htmlFor="vesselNationality">
-          Vessel nationality
+          Vessel nationality (optional)
         </label>
         <input
           className="govuk-input"
@@ -106,7 +106,7 @@ const FormVessel = ({
 
       <div id="portOfRegistry" className="govuk-form-group">
         <label className="govuk-label" htmlFor="portOfRegistry">
-          Port of registry
+          Port of registry (optional)
         </label>
         <input
           className="govuk-input"


### PR DESCRIPTION
This branch marks the fields on the create a vessel page as optional and adds validation to the mobile number when a user registers (allows numbers and whitespaces only).

To test:
When signed out, attempt to register a user with a phone number that contains anything other than a digit or whitespace. Submit and you will see an error message.
Navigate to the create a vessel page (http://localhost:8080/vessels/save-vessel?source=vessels) - you will see optional on the relevant field labels.

## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [x] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
