### PR TITLE
COP-2958: Fix a11y issue of report tabs not accessible by keyboard

### DIFF
--- a/src/components/ManageReports.jsx
+++ b/src/components/ManageReports.jsx
@@ -75,12 +75,19 @@ const ManageReports = (pageData) => {
               return (
                 <li
                   key={tab.name}
-                  className={tab.active === true ? 'govuk-tabs__list-item govuk-tabs__list-item--selected' : 'govuk-tabs__list-item'}
-                  onClick={(e) => setActiveTab(e)}
+                  className={tab.active ? 'govuk-tabs__list-item govuk-tabs__list-item--selected' : 'govuk-tabs__list-item'}
                 >
-                  <p id={tab.name} className="govuk-tabs__tab">
+                  <a
+                    href={`#${tab.name}`}
+                    id={tab.name}
+                    className="govuk-tabs__tab"
+                    onClick={(e) => {
+                      setActiveTab(e);
+                      e.preventDefault();
+                    }}
+                  >
                     {tab.text}
-                  </p>
+                  </a>
                 </li>
               );
             })}


### PR DESCRIPTION
## Description

Fixes an issue when user is unable to tab between draft, submitted and cancelled tabs (keyboard only navigation).

## Testing
1. Go to the homepage
2. Click View existing reports
3. Try switching between tabs using only keyboard

## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [x] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
