### PR TITLE
COP-2962/COP-4076: Update Manage Reports page to be mobile responsive and update Matomo code

### DIFF
--- a/cypress/integration/sGMR/add-voyage-report-with-saved-data.spec.js
+++ b/cypress/integration/sGMR/add-voyage-report-with-saved-data.spec.js
@@ -8,7 +8,6 @@ describe('Add report with saved data', () => {
   let vessel;
   let persons = [];
   let departDate;
-  let departTime;
   const numberOfPersons = 3;
 
   before(() => {
@@ -36,7 +35,6 @@ describe('Add report with saved data', () => {
     arrivalPort = 'Felixstowe';
     departureDateTime = getFutureDate(1, 'DD/MM/YYYY HH:MM');
     departDate = departureDateTime.split(' ')[0];
-    departTime = departureDateTime.split(' ')[1];
     arrivalDateTime = getFutureDate(2, 'DD/MM/YYYY HH:MM');
 
     cy.login();
@@ -52,10 +50,8 @@ describe('Add report with saved data', () => {
       {
         'Vessel': vessel.name,
         'Departure date': departDate,
-        'Departure time': `${departTime}:00`,
         'Departure port': 'DVR',
         'Arrival port': 'FXT',
-        'Submission reference': '',
       },
     ];
     cy.enterDepartureDetails(departureDateTime, departurePort);
@@ -110,10 +106,8 @@ describe('Add report with saved data', () => {
       {
         'Vessel': vessel.name,
         'Departure date': departDate,
-        'Departure time': `${departTime}:00`,
         'Departure port': 'DVR',
         'Arrival port': 'FXT',
-        'Submission reference': '',
       },
     ];
     cy.enterDepartureDetails(departureDateTime, departurePort);

--- a/cypress/integration/sGMR/add-voyage-report.spec.js
+++ b/cypress/integration/sGMR/add-voyage-report.spec.js
@@ -8,7 +8,6 @@ describe('Add new voyage report', () => {
   let vessel;
   let person;
   let departDate;
-  let departTime;
 
   before(() => {
     cy.registerUser();
@@ -29,7 +28,6 @@ describe('Add new voyage report', () => {
     arrivalPort = 'Felixstowe';
     departureDateTime = getFutureDate(1, 'DD/MM/YYYY HH:MM');
     departDate = departureDateTime.split(' ')[0];
-    departTime = departureDateTime.split(' ')[1];
     arrivalDateTime = getFutureDate(2, 'DD/MM/YYYY HH:MM');
 
     cy.navigation('Reports');
@@ -43,10 +41,8 @@ describe('Add new voyage report', () => {
       {
         'Vessel': vessel.name,
         'Departure date': departDate,
-        'Departure time': `${departTime}:00`,
         'Departure port': 'DVR',
         'Arrival port': 'FXT',
-        'Submission reference': '',
       },
     ];
     cy.checkAccessibility();
@@ -113,10 +109,8 @@ describe('Add new voyage report', () => {
       {
         'Vessel': vessel.name,
         'Departure date': departDate,
-        'Departure time': `${departTime}:00`,
         'Departure port': 'DVR',
         'Arrival port': 'FXT',
-        'Submission reference': '',
       },
     ];
     cy.enterDepartureDetails(departureDateTime, departurePort);
@@ -156,10 +150,8 @@ describe('Add new voyage report', () => {
       {
         'Vessel': vessel.name,
         'Departure date': departDate,
-        'Departure time': `${departTime}:00`,
         'Departure port': 'DVR',
         'Arrival port': 'FXT',
-        'Submission reference': '',
       },
     ];
     cy.enterDepartureDetails(departureDateTime, departurePort);

--- a/cypress/integration/sGMR/edit-existing-details-report-before-submit.spec.js
+++ b/cypress/integration/sGMR/edit-existing-details-report-before-submit.spec.js
@@ -8,7 +8,6 @@ describe('Edit Details & Submit new voyage report', () => {
   let vessel;
   let person;
   let departDate;
-  let departTime;
 
   before(() => {
     cy.registerUser();
@@ -25,7 +24,6 @@ describe('Edit Details & Submit new voyage report', () => {
     arrivalPort = 'Felixstowe';
     departureDateTime = getFutureDate(1, 'DD/MM/YYYY HH:MM');
     departDate = departureDateTime.split(' ')[0];
-    departTime = departureDateTime.split(' ')[1];
     arrivalDateTime = getFutureDate(2, 'DD/MM/YYYY HH:MM');
 
     cy.navigation('Reports');
@@ -60,17 +58,14 @@ describe('Edit Details & Submit new voyage report', () => {
     departureDateTime = getFutureDate(2, 'DD/MM/YYYY HH:MM');
     departurePort = 'London';
     departDate = departureDateTime.split(' ')[0];
-    departTime = departureDateTime.split(' ')[1];
     arrivalDateTime = getFutureDate(2, 'DD/MM/YYYY HH:MM');
     arrivalPort = 'Swansea';
     const expectedReport = [
       {
         'Vessel': vessel.name,
         'Departure date': departDate,
-        'Departure time': `${departTime}:00`,
         'Departure port': 'LGP',
         'Arrival port': 'Swansea Marina',
-        'Submission reference': '',
       },
     ];
     cy.get('a[href="/save-voyage/page-1"]').click();
@@ -117,10 +112,8 @@ describe('Edit Details & Submit new voyage report', () => {
       {
         'Vessel': vessel.name,
         'Departure date': departDate,
-        'Departure time': `${departTime}:00`,
         'Departure port': 'DVR',
         'Arrival port': 'FXT',
-        'Submission reference': '',
       },
     ];
     cy.get('a[href="/save-voyage/page-3"]').click();

--- a/index.html
+++ b/index.html
@@ -26,12 +26,13 @@
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
     (function() {
-      var u="https://matomo.dev.cop.homeoffice.gov.uk/";
+      var u="https://matomo.cop.homeoffice.gov.uk/";
       _paq.push(['setTrackerUrl', u+'matomo.php']);
-      _paq.push(['setSiteId', '6']);
+      _paq.push(['setSiteId', '9']);
       var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
       g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
     })();
   </script>
+  <!-- End Matomo Code -->
 </body>
 </html>

--- a/src/components/ManageReports.jsx
+++ b/src/components/ManageReports.jsx
@@ -100,10 +100,8 @@ const ManageReports = (pageData) => {
                 <tr className="govuk-table__row">
                   <th scope="col" className="govuk-table__header">Vessel</th>
                   <th scope="col" className="govuk-table__header">Departure date</th>
-                  <th scope="col" className="govuk-table__header">Departure time</th>
                   <th scope="col" className="govuk-table__header">Departure port</th>
                   <th scope="col" className="govuk-table__header">Arrival port</th>
-                  <th scope="col" className="govuk-table__header">Submission reference</th>
                 </tr>
               </thead>
               <tbody>
@@ -129,10 +127,8 @@ const ManageReports = (pageData) => {
                             {formatUIDate(voyage.departureDate)}
                           </Link>
                         </td>
-                        <td className="govuk-table__cell">{voyage.departureTime}</td>
                         <td className="govuk-table__cell">{voyage.departurePort}</td>
                         <td className="govuk-table__cell">{voyage.arrivalPort}</td>
-                        <td className="govuk-table__cell">{voyage.cbpId && voyage.cbpId}</td>
                       </tr>
                     );
                   }


### PR DESCRIPTION
## Description
This branch updates the Manage Reports page to be suitable for mobile devices. Beforehand the table would overflow for smaller screen sizes - confirmed with Christina that the Departure Time and Submission reference do not need to be displayed in the overview table so removed these. Also update the Matomo code to the prod url. 

To test:
- visit http://localhost:8080/manage-reports and inspect at different screen sizes. 

## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
