### PR TITLE
COP-4355/6: Fix bugs on Vessel and People page

### DIFF
--- a/src/components/People/FormPerson.jsx
+++ b/src/components/People/FormPerson.jsx
@@ -297,18 +297,18 @@ const FormPerson = ({
               </label>
             </div>
             <div className="govuk-radios__item">
+              <input
+                className="govuk-radios__input"
+                id="documentType-3"
+                name="documentType"
+                type="radio"
+                value="Other"
+                checked={(formData.documentType === 'Other' || data.documentType === 'Other') ? 'checked' : ''}
+                onChange={(e) => {
+                  handleChange(e);
+                }}
+              />
               <label className="govuk-label govuk-radios__label" htmlFor="documentType-3">
-                <input
-                  className="govuk-radios__input"
-                  id="documentType-3"
-                  name="documentType"
-                  type="radio"
-                  value="Other"
-                  checked={(formData.documentType === 'Other' || data.documentType === 'Other') ? 'checked' : ''}
-                  onChange={(e) => {
-                    handleChange(e);
-                  }}
-                />
                 Other
               </label>
             </div>

--- a/src/components/Voyage/VoyageFormDataFormatting.js
+++ b/src/components/Voyage/VoyageFormDataFormatting.js
@@ -123,6 +123,7 @@ const formatVessel = (status, data, voyageData) => {
         || item[0] === 'registration'
         || item[0] === 'moorings'
         || item[0] === 'callsign'
+        || item[0] === 'portOfRegistry'
       )
       && data[item[0]] !== item[1] // and value from voyageData !== value from form
     ) {


### PR DESCRIPTION
## Description

This branch addresses the bugs flagged in:
- COP-4355 : the Port of Registry on the Vessel page was not being fed through in the data package when a voyage is submitted
- COP-4356 :  the "Other" option under Travel Document details on the Add a  Person page was not clickable

To test: 
- Submit a voyage selecting the "Other" option for Travel document when adding a new person, and fill in the Port of Registry on the Vessel page. These will now be correctly populated on the check page and submitted correctly.

## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
