### PR TITLE
Attach Screenshots for the failed tests in the Mochawesome report

### DIFF
--- a/cypress/integration/sGMR/add-people.spec.js
+++ b/cypress/integration/sGMR/add-people.spec.js
@@ -56,7 +56,7 @@ describe('Add People in account', () => {
     cy.get('.govuk-error-message').should('contain.text', 'This person already exists').and('be.visible');
   });
 
-  it('Should not add people when Clicking on "Exit without saving" button', () => {
+  it('Should not add people when Clicking on Exit without saving button', () => {
     cy.contains('a', 'Save a person').should('have.text', 'Save a person').click();
     cy.enterPeopleInfo(people);
     cy.get('#firstName [type="text"]').clear().type('Auto-test-no-save');

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -13,7 +13,22 @@ Cypress.on('uncaught:exception', () => {
 
 Cypress.on('test:after:run', (test, runnable) => {
   if (test.state === 'failed') {
-    const screenshotFileName = `${Cypress.config('screenshotsFolder')}/${Cypress.spec.name}/${runnable.parent.title} -- ${test.title} (failed).png`;
-    addContext({ test }, `assets/${Cypress.spec.name}/${screenshotFileName}`);
+    let item = runnable;
+    const nameParts = [runnable.title];
+
+    // Iterate through all parents and grab the titles
+    while (item.parent) {
+      nameParts.unshift(item.parent.title);
+      item = item.parent;
+    }
+
+    if (runnable.hookName) {
+      nameParts.push(`${runnable.hookName} hook`);
+    }
+
+    const fullTestName = nameParts.filter(Boolean).join(' -- ');
+    const screenshotPath = `assets/${Cypress.spec.name}/${fullTestName} (failed).png`.replace('  ', ' ');
+
+    addContext({ test }, screenshotPath);
   }
 });


### PR DESCRIPTION
## Description
This PR has Fix for the Screenshots attachment for the failed tests.

### How to run the tests & see the attachments ?
npm run cypress:test:report -- -e local  -m <MailSlurp_API_Key>

After the test execution, navigate to folder mochawesome-report and open mochawesome.html to see the reports.

## Developer Checklist

\* Required

- [ ] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
