### PR TITLE
SPCR-104: Fix text input labelling on Edit Account page

### DIFF
--- a/src/components/Forms/FormVoyageSubmitted.jsx
+++ b/src/components/Forms/FormVoyageSubmitted.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 const FormVoyageSubmitted = () => {
-  
   document.title = "Report Submitted";
 
   return (

--- a/src/components/User/EditAccount.jsx
+++ b/src/components/User/EditAccount.jsx
@@ -140,6 +140,7 @@ const EditAccount = () => {
                 <input
                   className="govuk-input"
                   name="firstName"
+                  id = "firstName"
                   type="text"
                   value={formData.firstName || ''}
                   onChange={handleChange}
@@ -153,6 +154,7 @@ const EditAccount = () => {
                 <input
                   className="govuk-input"
                   name="lastName"
+                  id ="lastName"
                   type="text"
                   value={formData.lastName || ''}
                   onChange={handleChange}
@@ -166,6 +168,7 @@ const EditAccount = () => {
                 <input
                   className="govuk-input"
                   name="mobileNumber"
+                  id="mobileNumber"
                   type="text"
                   value={formData.mobileNumber || ''}
                   onChange={handleChange}

--- a/src/components/__tests__/PageAccount.test.jsx
+++ b/src/components/__tests__/PageAccount.test.jsx
@@ -42,12 +42,10 @@ test('PageAccount displays the users details', () => {
 });
 
 test('Document title is displayed and changes when function is called', () => {
-
+  
   customRender(<PageAccount />, { providerProps });
-
   expect(document.title).toBe('Account');
   
   document.title = "Changed document title";
   expect(document.title).toBe('Changed document title');
-
 });


### PR DESCRIPTION
## Description
Fix incorrectly coded labels so that they can be read by a screen reader

## To Test
* Go to Edit Account page
* Enable a screen reader
* Click on an empty text field
* You should be able to hear the label being read out by the screen reader

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
