### PR TITLE
SPCR-100 Update address pattern, make second line optional

### DIFF
--- a/src/components/Forms/validationRules.js
+++ b/src/components/Forms/validationRules.js
@@ -171,12 +171,6 @@ export const responsiblePersonValidationRules = [
     message: 'You must enter the first line of your address',
   },
   {
-    inputField: 'responsibleAddressLine2',
-    errorDisplayId: 'responsibleAddressLine2',
-    type: 'required',
-    message: 'You must enter the second line of your address',
-  },
-  {
     inputField: 'responsibleTown',
     errorDisplayId: 'responsibleTown',
     type: 'required',

--- a/src/components/Voyage/FormResponsiblePerson.jsx
+++ b/src/components/Voyage/FormResponsiblePerson.jsx
@@ -78,9 +78,9 @@ const FormResponsiblePerson = ({
         </div>
         <div className="govuk-form-group">
           <label className="govuk-label" htmlFor="responsibleAddressLine2">
-            <span className="govuk-visually-hidden">Building and street line 2 of 2</span>
+            Address line 2 (optional)
+            <span className="govuk-visually-hidden">Building and street line 2 of 2 (optional)</span>
           </label>
-          <FormError error={errors.responsibleAddressLine2} />
           <input
             className="govuk-input"
             name="responsibleAddressLine2"

--- a/src/components/Voyage/__tests__/FormResponsiblePerson.test.jsx
+++ b/src/components/Voyage/__tests__/FormResponsiblePerson.test.jsx
@@ -10,7 +10,6 @@ test('Renders with errors', () => {
       responsibleSurname: 'responsibleSurnameValue',
       responsibleContactNo: 'responsibleContactNoValue',
       responsibleAddressLine1: 'responsibleAddressLine1Value',
-      responsibleAddressLine2: 'responsibleAddressLine2Value',
       responsibleTown: 'responsibleTownValue',
       responsibleCounty: 'responsibleCountyValue',
       responsiblePostcode: 'responsiblePostcodeValue',
@@ -20,7 +19,6 @@ test('Renders with errors', () => {
       responsibleSurname: 'responsibleSurnameError',
       responsibleContactNo: 'responsibleContactNoError',
       responsibleAddressLine1: 'responsibleAddressLine1Error',
-      responsibleAddressLine2: 'responsibleAddressLine2Error',
       responsibleTown: 'responsibleTownError',
       responsibleCounty: 'responsibleCountyError',
       responsiblePostcode: 'responsiblePostcodeError',
@@ -31,7 +29,6 @@ test('Renders with errors', () => {
   expect(screen.getByText('responsibleSurnameError')).toBeInTheDocument();
   expect(screen.getByText('responsibleContactNoError')).toBeInTheDocument();
   expect(screen.getByText('responsibleAddressLine1Error')).toBeInTheDocument();
-  expect(screen.getByText('responsibleAddressLine2Error')).toBeInTheDocument();
   expect(screen.getByText('responsibleTownError')).toBeInTheDocument();
   expect(screen.getByText('responsibleCountyError')).toBeInTheDocument();
   expect(screen.getByText('responsiblePostcodeError')).toBeInTheDocument();

--- a/src/components/Voyage/__tests__/VoyageFormValidation.test.js
+++ b/src/components/Voyage/__tests__/VoyageFormValidation.test.js
@@ -4,7 +4,6 @@ import { FORM_STEPS } from '@constants/ClientConstants';
 test('Validates responsible person', async () => {
   const expectedErrors = {
     responsibleAddressLine1: 'You must enter the first line of your address',
-    responsibleAddressLine2: 'You must enter the second line of your address',
     responsibleContactNo: 'You must enter a contact number',
     responsibleCounty: 'You must enter a country name',
     responsibleGivenName: 'You must enter a first name',


### PR DESCRIPTION
## Description
Make the second line of the address optional and add a label informing users it is optional.

Warning: This has the potential to break after refactoring error handling as there is a chance backend validation isn't being reached currently. 

### To test
Go to the Add Skipper's address page (6 of 7)
Scroll to Address
The second input field should have an optional label
Leave this input empty
Submit the form
No error should occur for this input
The form should also submit when this input has text

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
