### PR TITLE
SPCR-145 Rename 'Submit a Pleasure Craft Report' to 'Tell Border Force and HMR…

### DIFF
--- a/cypress/integration/sGMR/user-register.spec.js
+++ b/cypress/integration/sGMR/user-register.spec.js
@@ -18,7 +18,7 @@ describe('User Registration', () => {
     cy.visit('/');
     cy.injectAxe();
     cy.checkAccessibility();
-    cy.get('.govuk-heading-l').should('have.text', 'Submit a Pleasure Craft Report');
+    cy.get('.govuk-heading-l').should('have.text', 'Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft');
     cy.get('.govuk-list .govuk-link').each((link, index) => {
       cy.wrap(link).should('contain.text', externalURLs[index]);
     });

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
 <head>
   <meta charset="utf-8" />
-  <title>Submit a Pleasure Craft Report</title>
+  <title>Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#0b0c0c" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/components/AccessibilityStatement.jsx
+++ b/src/components/AccessibilityStatement.jsx
@@ -8,22 +8,22 @@ const AccessibilityStatement = () => {
       <main className="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
         <div className="govuk-grid-row">
           <div className="govuk-width-container">
-            <h1 className="govuk-heading-xl">Accessibility statement for Submit a Pleasure Craft Report</h1>
+            <h1 className="govuk-heading-xl">Accessibility statement for Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft</h1>
             <p className="govuk-body">
               We want everyone to be able to get and do what they need with this service, regardless of access needs, due to a disability or condition.
             </p>
             <p className="govuk-body">
-              This accessibility statement contains information about Submit a Pleasure Craft Report, available at
+              This accessibility statement contains information about Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft, available at
               {' '}
-              <a className="govuk-link" target="blank" href="/reports">Submit a Pleasure Craft Report (opens in new tab).</a>
+              <a className="govuk-link" target="blank" href="/reports">Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft (opens in new tab).</a>
             </p>
             <p className="govuk-body">
               This website is run by Border Force. We want as many people as possible to be able to use this website. For example, that means you should be able to:
             </p>
             <ul className="govuk-list govuk-list--bullet">
               <li>Navigate most of the website using just a keyboard.</li>
-              <li>Reach the main reports page from every page on Submit a Pleasure Craft Report</li>
-              <li>Read and navigate the order on Submit a Pleasure Craft Report as it is logical and intuitive/clear.</li>
+              <li>Reach the main reports page from every page on Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft</li>
+              <li>Read and navigate the order on Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft as it is logical and intuitive/clear.</li>
               <li>Tab through questions in the form whilst always having the focus visible.</li>
             </ul>
             <p className="govuk-body">
@@ -38,7 +38,7 @@ const AccessibilityStatement = () => {
             <p className="govuk-body">We aim to meet international accessibility guidelines. However, this may not always be possible, or we may have missed a problem.</p>
             <p className="govuk-body">Some people may find parts of this service difficult to use because:</p>
             <ul className="govuk-list govuk-list--bullet">
-              <li>Fields are only auto completed from information in the user’s profile on Submit a Pleasure Craft Report and not from their browser.</li>
+              <li>Fields are only auto completed from information in the user’s profile on Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft and not from their browser.</li>
               <li>
                 The JAWS screen reader does not read options in drop down lists and users are unable to use their keyboard to navigate through drop down lists with
                 JAWS running in the background.

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -54,7 +54,7 @@ const Dashboard = (pageData) => {
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-one-half">
           <h2 className="govuk-heading-m">Create a new report</h2>
-          <p className="govuk-body">You can use this online form to create and submit a Pleasure Craft Report to UK Border Force, notifying them of your travel plans.</p>
+          <p className="govuk-body">You can use this online form to create and tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft to UK Border Force, notifying them of your travel plans.</p>
           <button
             type="button"
             className="govuk-button govuk-button--start"

--- a/src/components/Help.jsx
+++ b/src/components/Help.jsx
@@ -19,7 +19,7 @@ const Help = () => {
             </p>
             <h2 className="govuk-heading-l">Support</h2>
             <p className="govuk-body">
-              You can get support with using this service by emailing the Submit a Pleasure Craft Report team at:
+              You can get support with using this service by emailing the Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft team at:
             </p>
             <p className="govuk-body">
               <a href="mailto: sgmrsupport@digital.homeoffice.gov.uk">

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import Auth from '@lib/Auth';
 
 const LandingPage = () => {
-  document.title = 'Submit a Pleasure Craft Report';
+  document.title = 'Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft';
 
   return (
     <div className="govuk-width-container">

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -9,7 +9,7 @@ import { LOGOUT_URL } from '@constants/ApiConstants';
 const Nav = () => {
   const location = useLocation();
   const history = useHistory();
-  const serviceName = 'Submit a Pleasure Craft Report';
+  const serviceName = 'Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft';
   const [navArray, setNavArray] = useState([]);
 
   const navData = [

--- a/src/components/PrivacyCookiePolicy.jsx
+++ b/src/components/PrivacyCookiePolicy.jsx
@@ -8,9 +8,9 @@ const PrivacyCookiePolicy = () => {
       <main className="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
         <div className="govuk-grid-row">
           <div className="govuk-width-container">
-            <h1 className="govuk-heading-l">Privacy notice for Submit a Pleasure Craft Report</h1>
+            <h1 className="govuk-heading-l">Privacy notice for Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft</h1>
             <p className="govuk-body">
-              Provision of the Submit a Pleasure Craft Report service is from the borders, immigration and citizenship system, which is part of the Home Office.
+              Provision of the Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft service is from the borders, immigration and citizenship system, which is part of the Home Office.
               Please visit the guidance at
               {' '}
               <a href="https://www.gov.uk/government/publications/personal-information-use-in-borders-immigration-and-citizenship">
@@ -20,7 +20,7 @@ const PrivacyCookiePolicy = () => {
               for full information on how your personal information may be used within the Home Office Borders, Immigration and Citizenship System.
             </p>
             <h2 className="govuk-heading-m">What data we need</h2>
-            <p className="govuk-body">The personal data we collect from you on the Submit a Pleasure Craft Report service may include:</p>
+            <p className="govuk-body">The personal data we collect from you on the Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft service may include:</p>
             <ul className="govuk-list govuk-list--bullet">
               <li>your full name</li>
               <li>other travel document information such as document number and expiry date</li>
@@ -29,7 +29,7 @@ const PrivacyCookiePolicy = () => {
               <li>
                 information on how you use the site, using cookies and page tagging techniques:
                 <ul className="govuk-list govuk-list--bullet">
-                  <li>the pages you visit on Submit a Pleasure Craft Report</li>
+                  <li>the pages you visit on Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft</li>
                   <li>how long you spend on each page</li>
                   <li>what you click on while you’re visiting the site</li>
                 </ul>
@@ -38,7 +38,7 @@ const PrivacyCookiePolicy = () => {
             <p className="govuk-body">
               Under the Data Protection Act 2018, we are processing your personal information on a performance-of-a-public-task basis to allow Border Force to discharge our
               duties around your entry into the United Kingdom.
-              We may process your information in systems other that the Submit a Pleasure Craft Report Service. The legislative basis for collecting this information is the
+              We may process your information in systems other that the Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft Service. The legislative basis for collecting this information is the
               Immigration Act of 1971 Paragraph 27B.
             </p>
             <h2 className="govuk-heading-l">Cookies</h2>
@@ -50,12 +50,12 @@ const PrivacyCookiePolicy = () => {
             <h2 className="govuk-heading-m">How cookies are used</h2>
             <h3 className="govuk-heading-s">Measuring website usage</h3>
             <p className="govuk-body">
-              We use cookies to collect information as you interact with the Submit a Pleasure Craft Report. We do this to help make sure the site is meeting the needs of
+              We use cookies to collect information as you interact with the Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft. We do this to help make sure the site is meeting the needs of
               its users and to help us make improvements. Cookies will be used to monitor specific user information to improve your access to the form by remembering your
               non-personal details for the next time you submit a form.
             </p>
             <h3 className="govuk-heading-s">Cookie Details</h3>
-            <p className="govuk-body">Submit a Pleasure Craft Report uses cookies. The two types of persistent cookies are:</p>
+            <p className="govuk-body">Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft uses cookies. The two types of persistent cookies are:</p>
             <ul className="govuk-list govuk-list--bullet">
               <li>_pk_id: used to store a few details about you such as the unique visitor ID, stored for 13 months; and</li>
               <li>_pk_ref: used to store information to initially identify you when you visit the website, stored for 6 months.</li>
@@ -67,12 +67,12 @@ const PrivacyCookiePolicy = () => {
             </ul>
             <h2 className="govuk-heading-m">Cookie Introductory Message</h2>
             <p className="govuk-body">
-              You may see a Cookie Notice pop-up message when you first submit a Pleasure Craft Report. This message is to advise you that the process will capture cookies
+              You may see a Cookie Notice pop-up message when you first tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft. This message is to advise you that the process will capture cookies
               as described above. By accessing the Pleasure Craft Report form, you are consenting to the use of cookies described above.
             </p>
             <h2 className="govuk-heading-m">Why we need this data</h2>
             <p className="govuk-body">
-              We use cookie information to enable you to log into the service that we provide and to link information you add into Submit a Pleasure Craft Report to your
+              We use cookie information to enable you to log into the service that we provide and to link information you add into Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft to your
               account.
             </p>
             <p className="govuk-body">We use the information you provide to help ensure that we can enforce access control and keep data secure.</p>


### PR DESCRIPTION
## Description
We have new user flows being tested with users. In the meantime, we should take the content on the prototype and update the existing pages on the service to match.

All user-visible mentions of "Submit a Pleasure Craft Report" have been replaced by “Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft”.

## To Test
- Go to any page which would have previously contained "Submit a Pleasure Craft Report"
- Ctrl + F in your browser and type "Submit a Pleasure Craft Report"
- You should get no results
- Ctrl + F in your browser and type “Tell Border Force and HMRC you are sailing to or from the UK in a pleasure craft”
- You should get at least one result

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [X] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.