### PR TITLE
SPCR-168 Update people table to reflect the new naming conventions for people type

### DIFF
--- a/src/components/SectionTablePeople.jsx
+++ b/src/components/SectionTablePeople.jsx
@@ -16,6 +16,17 @@ const SectionTablePeople = ({ pageData }) => {
       .then((resp) => { setPeopleData(resp); });
   };
 
+  const getPersonType = (personType) => {
+    switch (personType) {
+      case 'Skipper':
+        return 'Skipper';
+      case 'Passenger':
+        return 'Unpaid Crew';
+      default:
+        return 'Employed Crew';
+    }
+  };
+
   useEffect(() => {
     storeData();
     const { reportTitles } = pageData;
@@ -59,7 +70,7 @@ const SectionTablePeople = ({ pageData }) => {
                         </Link>
                       </td>
                       <td className="govuk-table__cell">{person[1].firstName}</td>
-                      <td className="govuk-table__cell">{person[1].peopleType.name}</td>
+                      <td className="govuk-table__cell">{getPersonType(person[1].peopleType.name)}</td>
                     </tr>
                   );
                 })}

--- a/src/components/Voyage/PeopleSummary.jsx
+++ b/src/components/Voyage/PeopleSummary.jsx
@@ -10,8 +10,8 @@ import Details from '../Details';
 const PeopleSummary = ({ voyageId, source }) => {
   const [manifestData, setManifestData] = useState();
 
-  const getPersonType = (person) => {
-    switch (person.peopleType.name) {
+  const getPersonType = (personType) => {
+    switch (personType) {
       case 'Skipper':
         return 'Skipper';
       case 'Passenger':
@@ -49,7 +49,7 @@ const PeopleSummary = ({ voyageId, source }) => {
                 <td className="govuk-table__cell">{formatUIDate(person.dateOfBirth)}</td>
                 <td className="govuk-table__cell">{person.documentNumber}</td>
                 <td className="govuk-table__cell">{person.nationality}</td>
-                <td className="govuk-table__cell">{getPersonType(person)}</td>
+                <td className="govuk-table__cell">{getPersonType(person.peopleType.name)}</td>
               </tr>
 
               <tr className="govuk-table__row">


### PR DESCRIPTION
## Description
We have discovered the table of people on the /people page shows the old naming for people type and this needs updating.

## To Test
- **Given** I am on /people
- **When** I view my list of saved people
- **Then** I see them listed as `skipper`, `employed crew`, or `paid crew`

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
