### PR TITLE
SPCR-145 Rename 'manifest' to 'voyage plan'

### DIFF
--- a/src/components/People/FormPerson.jsx
+++ b/src/components/People/FormPerson.jsx
@@ -440,7 +440,7 @@ const FormPerson = ({
           data-module="govuk-button"
           onClick={(e) => handleSubmit(e, 'newPerson', voyageId)}
         >
-          {source === 'voyage' ? 'Add to manifest' : 'Add to saved people list'}
+          {source === 'voyage' ? 'Add to voyage plan' : 'Add to saved people list'}
         </button>
       </div>
 

--- a/src/components/Voyage/FormVoyagePeople.jsx
+++ b/src/components/Voyage/FormVoyagePeople.jsx
@@ -106,7 +106,7 @@ const FormVoyagePeople = ({
       {!!voyagePeople.length && (
         <>
           <p className="govuk-body-l">
-            People already added to the manifest:
+            People already added to the voyage plan:
             <br />
             {voyagePeople.map(({ firstName, lastName }) => `${firstName} ${lastName}`).join(', ')}
           </p>

--- a/src/components/Voyage/FormVoyagePeopleManifest.jsx
+++ b/src/components/Voyage/FormVoyagePeopleManifest.jsx
@@ -9,7 +9,7 @@ import PeopleTable from './PeopleTable';
 const FormVoyagePeopleManifest = ({
   handleSubmit, voyageId, setErrors,
 }) => {
-  document.title = 'People on the manifest';
+  document.title = 'People on the voyage plan';
 
   const [peopleData, setPeopleData] = useState([]);
   const [makeChanges, setMakeChanges] = useState(false);
@@ -49,12 +49,12 @@ const FormVoyagePeopleManifest = ({
 
   return (
     <section>
-      <h1 className="govuk-heading-xl">People on the manifest</h1>
+      <h1 className="govuk-heading-xl">People on the voyage plan</h1>
 
       <p className="govuk-body-l">
         {peopleData.length
           ? 'The people you have selected for this voyage are:'
-          : 'There are no people on the manifest.'}
+          : 'There are no people on the voyage plan.'}
       </p>
 
       {!!peopleData.length && (


### PR DESCRIPTION
## Description
We have new user flows being tested with users. In the meantime, we should take the content on the prototype and update the existing pages on the service to match.

All user-visible mentions of "manifest" have been replaced by “voyage plan”.

## To Test
- Go to any page which would have previously contained "manifest"
- Ctrl + F in your browser and type "manifest"
- You should get no results
- Ctrl + F in your browser and type “voyage plan”
- You should get at least one result

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
