### PR TITLE
SPCR-202 Rename 'vessel' to 'pleasure craft' (Cypress)

### DIFF
--- a/cypress/integration/sGMR/add-vessel.spec.js
+++ b/cypress/integration/sGMR/add-vessel.spec.js
@@ -1,4 +1,4 @@
-describe('Add new vessel in account', () => {
+describe('Add new pleasure craft in account', () => {
   let vessel;
 
   before(() => {
@@ -12,24 +12,24 @@ describe('Add new vessel in account', () => {
   beforeEach(() => {
     cy.login();
     cy.injectAxe();
-    cy.navigation('Vessels');
+    cy.navigation('Pleasure Crafts');
   });
 
-  it('Should add a new Vessel', () => {
+  it('Should add a new Pleasure Craft', () => {
     cy.checkAccessibility();
     cy.addVessel(vessel);
     cy.checkAccessibility();
   });
 
-  it('Should not add a vessel without submitting required data', () => {
+  it('Should not add a pleasure craft without submitting required data', () => {
     const errors = [
-      'You must enter a vessel name',
-      'You must enter a vessel type',
-      'You must enter the vessel usual mooring',
-      'You must enter the vessel registration',
+      'You must enter a pleasure craft name',
+      'You must enter a pleasure craft type',
+      'You must enter the pleasure craft usual mooring',
+      'You must enter the pleasure craft registration',
     ];
 
-    cy.contains('a', 'Save a vessel').should('have.text', 'Save a vessel').click();
+    cy.contains('a', 'Save a pleasure craft').should('have.text', 'Save a pleasure craft').click();
 
     cy.get('.govuk-button').click();
 
@@ -38,15 +38,15 @@ describe('Add new vessel in account', () => {
     });
   });
 
-  it('Should not allow adding a duplicate vessel', () => {
-    cy.contains('a', 'Save a vessel').should('have.text', 'Save a vessel').click();
+  it('Should not allow adding a duplicate pleasure craft', () => {
+    cy.contains('a', 'Save a pleasure craft').should('have.text', 'Save a pleasure craft').click();
     cy.enterVesselInfo(vessel);
     cy.get('.govuk-button').click();
-    cy.get('.govuk-error-message').should('contain.text', 'This vessel already exists').and('be.visible');
+    cy.get('.govuk-error-message').should('contain.text', 'This pleasure craft already exists').and('be.visible');
   });
 
-  it('Should not add a vessel when Clicking on "Exit without saving" button', () => {
-    cy.contains('a', 'Save a vessel').should('have.text', 'Save a vessel').click();
+  it('Should not add a pleasure craft when Clicking on "Exit without saving" button', () => {
+    cy.contains('a', 'Save a pleasure craft').should('have.text', 'Save a pleasure craft').click();
     cy.enterVesselInfo(vessel);
     cy.get('[name="vesselName"]').clear().type('Titanic');
     cy.get('[name="registration"]').clear().type('9999999');

--- a/cypress/integration/sGMR/add-voyage-report-with-saved-data.spec.js
+++ b/cypress/integration/sGMR/add-voyage-report-with-saved-data.spec.js
@@ -23,7 +23,7 @@ describe('Add report with saved data', () => {
       });
     }
 
-    cy.navigation('Vessels');
+    cy.navigation('Pleasure Crafts');
 
     cy.getVesselObj().then((vesselObj) => {
       vessel = vesselObj;
@@ -48,7 +48,7 @@ describe('Add report with saved data', () => {
     cy.get('.govuk-button--start').should('have.text', 'Start now').click();
   });
 
-  it('Should be able to Cancel a submitted report using Saved People & Vessel', () => {
+  it('Should be able to Cancel a submitted report using Saved People & Pleasure Craft', () => {
     const expectedReport = [
       {
         'Vessel': vessel.name,

--- a/cypress/integration/sGMR/edit-existing-details-report-before-submit.spec.js
+++ b/cypress/integration/sGMR/edit-existing-details-report-before-submit.spec.js
@@ -107,7 +107,7 @@ describe('Edit Details & Submit new voyage report', () => {
     });
   });
 
-  it('Should be able to edit Vessel and Person details before submit the report', () => {
+  it('Should be able to edit Pleasure Craft and Person details before submit the report', () => {
     cy.getVesselObj().then((vesselObj) => {
       vessel = vesselObj;
     });

--- a/cypress/integration/sGMR/edit-vessel.spec.js
+++ b/cypress/integration/sGMR/edit-vessel.spec.js
@@ -1,10 +1,10 @@
-describe('Edit existing vessel information', () => {
+describe('Edit existing pleasure craft information', () => {
   let vessel;
 
   before(() => {
     cy.registerUser();
     cy.login();
-    cy.navigation('Vessels');
+    cy.navigation('Pleasure Crafts');
 
     cy.getVesselObj().then((vesselObj) => {
       vessel = vesselObj;
@@ -14,11 +14,11 @@ describe('Edit existing vessel information', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.navigation('Vessels');
-    cy.url().should('include', '/vessels');
+    cy.navigation('Pleasure Crafts');
+    cy.url().should('include', '/pleasure-crafts');
   });
 
-  it('Should be able to edit existing vessel information and save', () => {
+  it('Should be able to edit existing pleasure craft information and save', () => {
     cy.get('.govuk-table td a').contains(vessel.name).click();
     vessel.name = 'Auto-test-edit-1234';
     vessel.type = 'Sailboat';
@@ -32,14 +32,14 @@ describe('Edit existing vessel information', () => {
     cy.get('table').getTable().then((vesselData) => {
       expect(vesselData).to.not.be.empty;
       expect(vesselData).to.deep.include({
-        'Vessel name': vessel.name,
-        'Vessel type': vessel.type,
+        'Pleasure craft name': vessel.name,
+        'Pleasure craft type': vessel.type,
         'Usual moorings': vessel.moorings,
       });
     });
   });
 
-  it('Should be able to edit existing vessel information and NOT save', () => {
+  it('Should be able to edit existing pleasure craft information and NOT save', () => {
     cy.get('.govuk-table td a').contains(vessel.name).click();
     cy.get('[name="vesselName"]').click().clear().type('Auto-test-edit-5555');
     cy.get('[name="vesselType"]').clear().type('Sailboat');
@@ -50,8 +50,8 @@ describe('Edit existing vessel information', () => {
     cy.get('table').getTable().then((vesselData) => {
       expect(vesselData).to.not.be.empty;
       expect(vesselData).to.deep.include({
-        'Vessel name': vessel.name,
-        'Vessel type': vessel.type,
+        'Pleasure craft name': vessel.name,
+        'Pleasure craft type': vessel.type,
         'Usual moorings': vessel.moorings,
       });
     });

--- a/cypress/integration/sGMR/report-form-validation.spec.js
+++ b/cypress/integration/sGMR/report-form-validation.spec.js
@@ -19,7 +19,7 @@ describe('Validate report form', () => {
       cy.addPeople(people);
     });
 
-    cy.navigation('Vessels');
+    cy.navigation('Pleasure Crafts');
 
     cy.getVesselObj().then((vesselObj) => {
       vessel = vesselObj;
@@ -67,12 +67,12 @@ describe('Validate report form', () => {
     });
   });
 
-  it('Should verify Vessel details mandatory data', () => {
+  it('Should verify Pleasure Craft details mandatory data', () => {
     const errors = [
-      'You must enter a vessel name',
-      'You must enter a vessel type',
-      'You must enter the vessel usual mooring',
-      'You must enter the vessel registration',
+      'You must enter a pleasure craft name',
+      'You must enter a pleasure craft type',
+      'You must enter the pleasure craft usual mooring',
+      'You must enter the pleasure craft registration',
     ];
 
     cy.enterDepartureDetails(departureDateTime, departurePort);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -203,14 +203,14 @@ Cypress.Commands.add('addPeople', (person) => {
 });
 
 Cypress.Commands.add('addVessel', (vessel) => {
-  cy.contains('a', 'Save a vessel').should('have.text', 'Save a vessel').click();
+  cy.contains('a', 'Save a pleasure craft').should('have.text', 'Save a pleasure craft').click();
   cy.enterVesselInfo(vessel);
   cy.get('.govuk-button').click();
   cy.get('.govuk-error-message').should('not.be.visible');
   cy.get('table').getTable().then((vesselData) => {
     expect(vesselData).to.deep.include({
-      'Vessel name': vessel.name,
-      'Vessel type': vessel.type,
+      'Pleasure craft name': vessel.name,
+      'Pleasure craft type': vessel.type,
       'Usual moorings': vessel.moorings,
     });
   });


### PR DESCRIPTION
## Description
Certain words and phrases within the service have been refactored. This should also be done to the Cypress tests, otherwise they will throw an error.

All UI instances of ‘vessel’ have been replaced with ‘pleasure craft’ within the Cypress tests.

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [X] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.