### PR TITLE
SPCR-202 Rename 'report' to 'voyage plan' (Cypress)

### DIFF
--- a/cypress/integration/sGMR/add-voyage-report-with-saved-data.spec.js
+++ b/cypress/integration/sGMR/add-voyage-report-with-saved-data.spec.js
@@ -1,6 +1,6 @@
 const { getFutureDate } = require('../../support/utils');
 
-describe('Add report with saved data', () => {
+describe('Add voyage plan with saved data', () => {
   let departureDateTime;
   let departurePort;
   let arrivalDateTime;
@@ -40,7 +40,7 @@ describe('Add report with saved data', () => {
 
     cy.login();
     cy.injectAxe();
-    cy.url().should('include', '/reports');
+    cy.url().should('include', '/voyage-plans');
     cy.getNumberOfReports('Submitted').then((res) => {
       numberOfSubmittedReports = res;
     });
@@ -48,7 +48,7 @@ describe('Add report with saved data', () => {
     cy.get('.govuk-button--start').should('have.text', 'Start now').click();
   });
 
-  it('Should be able to Cancel a submitted report using Saved People & Pleasure Craft', () => {
+  it('Should be able to Cancel a submitted voyage plan using Saved People & Pleasure Craft', () => {
     const expectedReport = [
       {
         'Vessel': vessel.name,
@@ -63,12 +63,12 @@ describe('Add report with saved data', () => {
     cy.saveAndContinue();
     cy.checkNoErrors();
     cy.selectCheckbox(vessel.name);
-    cy.contains('Add to report').click();
+    cy.contains('Add to voyage plan').click();
     cy.saveAndContinue();
     cy.checkNoErrors();
     cy.wait(1000);
     cy.selectCheckbox(persons[0].lastName);
-    cy.contains('Add to report and continue').click();
+    cy.contains('Add to voyage plan and continue').click();
     cy.assertPeopleTable((reportData) => {
       expect(reportData).to.have.length(1);
     });
@@ -77,12 +77,12 @@ describe('Add report with saved data', () => {
     cy.enterSkipperDetails();
     cy.saveAndContinue();
     cy.checkNoErrors();
-    cy.contains('Accept and submit report').click();
+    cy.contains('Accept and submit voyage plan').click();
     cy.url().should('include', '/save-voyage/page-submitted');
-    cy.get('.govuk-panel__title').should('have.text', 'Pleasure Craft Report Submitted');
-    cy.navigation('Reports');
+    cy.get('.govuk-panel__title').should('have.text', 'Pleasure Craft Voyage Plan Submitted');
+    cy.navigation('Voyage Plans');
     cy.checkReports('Submitted', (+numberOfSubmittedReports) + (+1));
-    cy.contains('View existing reports').click();
+    cy.contains('View existing voyage plans').click();
     cy.get('.govuk-tabs__list li')
       .within(() => {
         cy.get('#submitted').should('have.text', 'Submitted')
@@ -94,7 +94,7 @@ describe('Add report with saved data', () => {
       expectedReport.forEach((item) => expect(reportData).to.deep.include(item));
       cy.get('.govuk-table td a').contains(vessel.name).click();
       cy.contains('Cancel voyage').click();
-      cy.contains('View existing reports').click();
+      cy.contains('View existing voyage plans').click();
       cy.get('.govuk-tabs__list li')
         .within(() => {
           cy.get('#cancelled').should('have.text', 'Cancelled')
@@ -104,7 +104,7 @@ describe('Add report with saved data', () => {
     });
   });
 
-  it('Should be able to submit a report with more than one passenger', () => {
+  it('Should be able to submit a voyage plan with more than one passenger', () => {
     const expectedReport = [
       {
         'Vessel': vessel.name,
@@ -119,14 +119,14 @@ describe('Add report with saved data', () => {
     cy.saveAndContinue();
     cy.checkNoErrors();
     cy.selectCheckbox(vessel.name);
-    cy.contains('Add to report').click();
+    cy.contains('Add to voyage plan').click();
     cy.saveAndContinue();
     cy.checkNoErrors();
     cy.wait(1000);
     for (let i = 0; i < numberOfPersons; i += 1) {
       cy.selectCheckbox(persons[i].lastName);
     }
-    cy.contains('Add to report and continue').click();
+    cy.contains('Add to voyage plan and continue').click();
     cy.assertPeopleTable((reportData) => {
       expect(reportData).to.have.length(3);
     });
@@ -135,12 +135,12 @@ describe('Add report with saved data', () => {
     cy.enterSkipperDetails();
     cy.saveAndContinue();
     cy.checkNoErrors();
-    cy.contains('Accept and submit report').click();
+    cy.contains('Accept and submit voyage plan').click();
     cy.url().should('include', '/save-voyage/page-submitted');
-    cy.get('.govuk-panel__title').should('have.text', 'Pleasure Craft Report Submitted');
-    cy.navigation('reports');
+    cy.get('.govuk-panel__title').should('have.text', 'Pleasure Craft Voyage Plan Submitted');
+    cy.navigation('Voyage Plans');
     cy.checkReports('Submitted', numberOfSubmittedReports);
-    cy.contains('View existing reports').click();
+    cy.contains('View existing voyage plans').click();
     cy.get('.govuk-tabs__list li')
       .within(() => {
         cy.get('#submitted').should('have.text', 'Submitted')

--- a/cypress/integration/sGMR/add-voyage-report.spec.js
+++ b/cypress/integration/sGMR/add-voyage-report.spec.js
@@ -1,6 +1,6 @@
 const { getFutureDate } = require('../../support/utils');
 
-describe('Add new voyage report', () => {
+describe('Add new voyage plan', () => {
   let departureDateTime;
   let departurePort;
   let arrivalDateTime;
@@ -33,8 +33,8 @@ describe('Add new voyage report', () => {
     departDate = departureDateTime.split(' ')[0];
     arrivalDateTime = getFutureDate(2, 'DD/MM/YYYY HH:MM');
 
-    cy.navigation('Reports');
-    cy.url().should('include', '/reports');
+    cy.navigation('Voyage Plans');
+    cy.url().should('include', '/voyage-plans');
     cy.getNumberOfReports('Draft').then((res) => {
       numberOfDraftReports = res;
     });
@@ -47,7 +47,7 @@ describe('Add new voyage report', () => {
     cy.get('.govuk-button--start').should('have.text', 'Start now').click();
   });
 
-  it('Should submit report successfully', () => {
+  it('Should submit voyage plan successfully', () => {
     const expectedReport = [
       {
         'Vessel': vessel.name,
@@ -97,12 +97,12 @@ describe('Add new voyage report', () => {
     cy.saveAndContinue();
     cy.checkNoErrors();
     cy.checkAccessibility();
-    cy.contains('Accept and submit report').click();
+    cy.contains('Accept and submit voyage plan').click();
     cy.url().should('include', '/save-voyage/page-submitted');
-    cy.get('.govuk-panel__title').should('have.text', 'Pleasure Craft Report Submitted');
-    cy.navigation('Reports');
+    cy.get('.govuk-panel__title').should('have.text', 'Pleasure Craft Voyage Plan Submitted');
+    cy.navigation('Voyage Plans');
     cy.checkReports('Submitted', (+numberOfSubmittedReports) + (+1));
-    cy.contains('View existing reports').click();
+    cy.contains('View existing voyage plans').click();
     cy.get('.govuk-tabs__list li')
       .within(() => {
         cy.get('#submitted').should('have.text', 'Submitted')
@@ -115,7 +115,7 @@ describe('Add new voyage report', () => {
     cy.checkAccessibility();
   });
 
-  it('Should be able to cancel report', () => {
+  it('Should be able to cancel voyage plan', () => {
     const expectedReport = [
       {
         'Vessel': vessel.name,
@@ -141,10 +141,10 @@ describe('Add new voyage report', () => {
     cy.saveAndContinue();
     cy.checkNoErrors();
     cy.contains('Cancel voyage').click();
-    cy.url().should('include', '/reports');
-    cy.navigation('Reports');
+    cy.url().should('include', '/voyage-plans');
+    cy.navigation('Voyage Plans');
     cy.checkReports('Cancelled', (+numberOfCancelledReports) + (+1));
-    cy.contains('View existing reports').click();
+    cy.contains('View existing voyage plans').click();
     cy.get('.govuk-tabs__list li')
       .within(() => {
         cy.get('#cancelled').should('have.text', 'Cancelled')
@@ -156,7 +156,7 @@ describe('Add new voyage report', () => {
     });
   });
 
-  it('Should be able to save report for later', () => {
+  it('Should be able to save voyage plan for later', () => {
     const expectedReport = [
       {
         'Vessel': vessel.name,
@@ -182,10 +182,10 @@ describe('Add new voyage report', () => {
     cy.saveAndContinue();
     cy.checkNoErrors();
     cy.contains('Exit without saving').click();
-    cy.url().should('include', '/reports');
-    cy.navigation('Reports');
+    cy.url().should('include', '/voyage-plans');
+    cy.navigation('Voyage Plans');
     cy.checkReports('Draft', (+numberOfDraftReports) + (+1));
-    cy.contains('View existing reports').click();
+    cy.contains('View existing voyage plans').click();
     cy.get('.govuk-tabs__list li')
       .within(() => {
         cy.get('#draft').should('have.text', 'Draft')

--- a/cypress/integration/sGMR/edit-existing-details-report-before-submit.spec.js
+++ b/cypress/integration/sGMR/edit-existing-details-report-before-submit.spec.js
@@ -1,6 +1,6 @@
 const { getFutureDate } = require('../../support/utils');
 
-describe('Edit Details & Submit new voyage report', () => {
+describe('Edit Details & Submit new voyage plan', () => {
   let departureDateTime;
   let departurePort;
   let arrivalDateTime;
@@ -27,8 +27,8 @@ describe('Edit Details & Submit new voyage report', () => {
     departDate = departureDateTime.split(' ')[0];
     arrivalDateTime = getFutureDate(2, 'DD/MM/YYYY HH:MM');
 
-    cy.navigation('Reports');
-    cy.url().should('include', '/reports');
+    cy.navigation('Voyage Plans');
+    cy.url().should('include', '/voyage-plans');
     cy.getNumberOfReports('Submitted').then((res) => {
       numberOfSubmittedReports = res;
     });
@@ -57,7 +57,7 @@ describe('Edit Details & Submit new voyage report', () => {
     cy.checkNoErrors();
   });
 
-  it('Should be able to edit Departure and Arrival details before submit the report', () => {
+  it('Should be able to edit Departure and Arrival details before submit the voyage plan', () => {
     departureDateTime = getFutureDate(2, 'DD/MM/YYYY HH:MM');
     departurePort = 'London';
     departDate = departureDateTime.split(' ')[0];
@@ -90,12 +90,12 @@ describe('Edit Details & Submit new voyage report', () => {
     cy.url().should('include', 'page-6');
     cy.saveAndContinue();
     cy.checkNoErrors();
-    cy.contains('Accept and submit report').click();
+    cy.contains('Accept and submit voyage plan').click();
     cy.url().should('include', '/save-voyage/page-submitted');
-    cy.get('.govuk-panel__title').should('have.text', 'Pleasure Craft Report Submitted');
-    cy.navigation('Reports');
+    cy.get('.govuk-panel__title').should('have.text', 'Pleasure Craft Voyage Plan Submitted');
+    cy.navigation('Voyage Plans');
     cy.checkReports('Submitted', (+numberOfSubmittedReports) + (+1));
-    cy.contains('View existing reports').click();
+    cy.contains('View existing voyage plans').click();
     cy.get('.govuk-tabs__list li')
       .within(() => {
         cy.get('#submitted').should('have.text', 'Submitted')
@@ -107,7 +107,7 @@ describe('Edit Details & Submit new voyage report', () => {
     });
   });
 
-  it('Should be able to edit Pleasure Craft and Person details before submit the report', () => {
+  it('Should be able to edit Pleasure Craft and Person details before submit the voyage plan', () => {
     cy.getVesselObj().then((vesselObj) => {
       vessel = vesselObj;
     });
@@ -132,12 +132,12 @@ describe('Edit Details & Submit new voyage report', () => {
     cy.url().should('include', 'page-6');
     cy.saveAndContinue();
     cy.checkNoErrors();
-    cy.contains('Accept and submit report').click();
+    cy.contains('Accept and submit voyage plan').click();
     cy.url().should('include', '/save-voyage/page-submitted');
-    cy.get('.govuk-panel__title').should('have.text', 'Pleasure Craft Report Submitted');
-    cy.navigation('Reports');
+    cy.get('.govuk-panel__title').should('have.text', 'Pleasure Craft Voyage Plan Submitted');
+    cy.navigation('Voyage Plans');
     cy.checkReports('Submitted', (+numberOfSubmittedReports) + (+1));
-    cy.contains('View existing reports').click();
+    cy.contains('View existing voyage plans').click();
     cy.get('.govuk-tabs__list li')
       .within(() => {
         cy.get('#submitted').should('have.text', 'Submitted')

--- a/cypress/integration/sGMR/report-form-validation.spec.js
+++ b/cypress/integration/sGMR/report-form-validation.spec.js
@@ -1,6 +1,6 @@
 const { getFutureDate } = require('../../support/utils');
 
-describe('Validate report form', () => {
+describe('Validate voyage plan form', () => {
   let departureDateTime;
   let departurePort;
   let arrivalDateTime;
@@ -34,8 +34,8 @@ describe('Validate report form', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.navigation('Reports');
-    cy.url().should('include', '/reports');
+    cy.navigation('Voyage Plans');
+    cy.url().should('include', '/voyage-plans');
     cy.get('.govuk-button--start').should('have.text', 'Start now').click();
   });
 

--- a/cypress/integration/sGMR/sign-in.spec.js
+++ b/cypress/integration/sGMR/sign-in.spec.js
@@ -21,7 +21,7 @@ describe('Sign-in flow', () => {
         expect(xhr.status).to.eq(200);
       });
     });
-    cy.url().should('include', '/reports');
+    cy.url().should('include', '/voyage-plans');
     cy.get('.govuk-button--start').should('have.text', 'Start now');
     cy.injectAxe();
     cy.checkAccessibility();

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -90,7 +90,7 @@ Cypress.Commands.add('login', () => {
       }
     });
   });
-  cy.navigation('Reports');
+  cy.navigation('Voyage Plans');
   cy.get('.govuk-button--start').should('have.text', 'Start now');
 });
 


### PR DESCRIPTION
## Description
Certain words and phrases within the service have been refactored. This should also be done to the Cypress tests, otherwise they will throw an error.

All UI instances of ‘report’ have been replaced with ‘voyage plan’ within the Cypress tests.

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [X] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.