### PR TITLE
SPCR-202 Rename 'manifest' to 'voyage plan' (Cypress)

### DIFF
--- a/cypress/integration/sGMR/add-voyage-report.spec.js
+++ b/cypress/integration/sGMR/add-voyage-report.spec.js
@@ -70,7 +70,7 @@ describe('Add new voyage plan', () => {
     cy.checkAccessibility();
     cy.contains('add a new person').click();
     cy.enterPeopleInfo(person);
-    cy.contains('Add to manifest').click();
+    cy.contains('Add to voyage plan').click();
     cy.assertPeopleTable((reportData) => {
       expect(reportData).to.have.length(1);
       expect(reportData[0]).to.deep.include({
@@ -79,14 +79,14 @@ describe('Add new voyage plan', () => {
       });
     });
     cy.saveAndContinueOnPeopleManifest(true);
-    cy.contains(`People already added to the manifest:${person.firstName} ${person.lastName}`);
+    cy.contains(`People already added to the voyage plan:${person.firstName} ${person.lastName}`);
     cy.saveAndContinue();
     cy.get('input[type="checkbox"]').eq(0).check();
     cy.contains('Remove person').click();
-    cy.contains('There are no people on the manifest.');
+    cy.contains('There are no people on the voyage plan.');
     cy.saveAndContinueOnPeopleManifest(true);
     cy.contains('add a new person').click();
-    cy.contains('Add to manifest').click();
+    cy.contains('Add to voyage plan').click();
     cy.assertPeopleTable((reportData) => {
       expect(reportData).to.have.length(1);
     });
@@ -134,7 +134,7 @@ describe('Add new voyage plan', () => {
     cy.checkNoErrors();
     cy.contains('add a new person').click();
     cy.enterPeopleInfo(person);
-    cy.contains('Add to manifest').click();
+    cy.contains('Add to voyage plan').click();
     cy.saveAndContinueOnPeopleManifest(false);
     cy.checkNoErrors();
     cy.enterSkipperDetails();
@@ -175,7 +175,7 @@ describe('Add new voyage plan', () => {
     cy.checkNoErrors();
     cy.contains('add a new person').click();
     cy.enterPeopleInfo(person);
-    cy.contains('Add to manifest').click();
+    cy.contains('Add to voyage plan').click();
     cy.saveAndContinueOnPeopleManifest(false);
     cy.checkNoErrors();
     cy.enterSkipperDetails();

--- a/cypress/integration/sGMR/edit-existing-details-report-before-submit.spec.js
+++ b/cypress/integration/sGMR/edit-existing-details-report-before-submit.spec.js
@@ -48,7 +48,7 @@ describe('Edit Details & Submit new voyage plan', () => {
     cy.getPersonObj().then((peopleObj) => {
       person = peopleObj;
       cy.enterPeopleInfo(person);
-      cy.contains('Add to manifest').click();
+      cy.contains('Add to voyage plan').click();
       cy.saveAndContinueOnPeopleManifest(false);
     });
     cy.checkNoErrors();

--- a/cypress/integration/sGMR/report-form-validation.spec.js
+++ b/cypress/integration/sGMR/report-form-validation.spec.js
@@ -109,7 +109,7 @@ describe('Validate voyage plan form', () => {
     cy.saveAndContinue();
     cy.url().should('include', '/page-4');
     cy.contains('add a new person').click();
-    cy.get('.govuk-button').contains('Add to manifest').click();
+    cy.get('.govuk-button').contains('Add to voyage plan').click();
     cy.get('.govuk-error-message').each((error, index) => {
       cy.wrap(error).should('contain.text', errors[index]).and('be.visible');
     });
@@ -135,7 +135,7 @@ describe('Validate voyage plan form', () => {
     cy.checkNoErrors();
     cy.contains('add a new person').click();
     cy.enterPeopleInfo(people);
-    cy.contains('Add to manifest').click();
+    cy.contains('Add to voyage plan').click();
     cy.saveAndContinueOnPeopleManifest(false);
     cy.checkNoErrors();
     cy.saveAndContinue();


### PR DESCRIPTION
## Description
Certain words and phrases within the service have been refactored. This should also be done to the Cypress tests, otherwise they will throw an error.

All UI instances of ‘manifest’ have been replaced with ‘voyage plan’ within the Cypress tests.

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [X] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
