### PR TITLE
SPCR-199 Fix error placement on departure and arrival forms

### DIFF
--- a/src/components/Voyage/VoyageFormValidation.js
+++ b/src/components/Voyage/VoyageFormValidation.js
@@ -2,7 +2,7 @@
 import { FORM_STEPS } from '../../constants/ClientConstants';
 import { isDateValid, isInThePast } from '../../utils/date';
 import scrollToTopOnError from '../../utils/scrollToTopOnError';
-import { isCurrentDateWithTimeBeforeNow, isTimeAndDateBeforeNow, isTimeValid } from '../../utils/time';
+import { isDateToday, isTimeAndDateBeforeNow, isTimeValid } from '../../utils/time';
 import {
   arrivalValidationRules,
   departureValidationRules,
@@ -87,40 +87,32 @@ const VoyageFormValidation = async (dataToValidate, source) => {
     errors.arrivalTime = 'You must enter a valid time';
   }
   // Departure date must be in the future
-  if (isCurrentDateWithTimeBeforeNow(
+  if (isTimeAndDateBeforeNow(
     dataToValidate.departureDateYear,
     dataToValidate.departureDateMonth,
     dataToValidate.departureDateDay,
     dataToValidate.departureTimeHour,
     dataToValidate.departureTimeMinute,
   )) {
-    errors.departureTime = 'You must enter a departure time in the future';
-  } else if (isTimeAndDateBeforeNow(
-    dataToValidate.departureDateYear,
-    dataToValidate.departureDateMonth,
-    dataToValidate.departureDateDay,
-    dataToValidate.departureTimeHour,
-    dataToValidate.departureTimeMinute,
-  )) {
-    errors.departureDate = 'You must enter a departure time in the future';
+    if (isDateToday(dataToValidate.departureDateYear, dataToValidate.departureDateMonth, dataToValidate.departureDateDay)) {
+      errors.departureTime = 'You must enter a departure time in the future';
+    } else {
+      errors.departureDate = 'You must enter a departure time in the future';
+    }
   }
   // Arrival date must be in the future
-  if (isCurrentDateWithTimeBeforeNow(
-    dataToValidate.departureDateYear,
-    dataToValidate.departureDateMonth,
-    dataToValidate.departureDateDay,
-    dataToValidate.departureTimeHour,
-    dataToValidate.departureTimeMinute,
-  )) {
-    errors.departureTime = 'You must enter a departure time in the future';
-  } else if (isTimeAndDateBeforeNow(
+  if (isTimeAndDateBeforeNow(
     dataToValidate.arrivalDateYear,
     dataToValidate.arrivalDateMonth,
     dataToValidate.arrivalDateDay,
     dataToValidate.arrivalTimeHour,
     dataToValidate.arrivalTimeMinute,
   )) {
-    errors.arrivalDate = 'You must enter an arrival time in the future';
+    if (isDateToday(dataToValidate.arrivalDateYear, dataToValidate.arrivalDateMonth, dataToValidate.arrivalDateDay)) {
+      errors.arrivalTime = 'You must enter an arrival time in the future';
+    } else {
+      errors.arrivalDate = 'You must enter an arrival time in the future';
+    }
   }
   // Arrival date must be after the departure date
   if (

--- a/src/components/Voyage/VoyageFormValidation.js
+++ b/src/components/Voyage/VoyageFormValidation.js
@@ -2,7 +2,7 @@
 import { FORM_STEPS } from '../../constants/ClientConstants';
 import { isDateValid, isInThePast } from '../../utils/date';
 import scrollToTopOnError from '../../utils/scrollToTopOnError';
-import { isTimeAndDateBeforeNow, isTimeValid } from '../../utils/time';
+import { isCurrentDateWithTimeBeforeNow, isTimeAndDateBeforeNow, isTimeValid } from '../../utils/time';
 import {
   arrivalValidationRules,
   departureValidationRules,
@@ -87,7 +87,15 @@ const VoyageFormValidation = async (dataToValidate, source) => {
     errors.arrivalTime = 'You must enter a valid time';
   }
   // Departure date must be in the future
-  if (isTimeAndDateBeforeNow(
+  if (isCurrentDateWithTimeBeforeNow(
+    dataToValidate.departureDateYear,
+    dataToValidate.departureDateMonth,
+    dataToValidate.departureDateDay,
+    dataToValidate.departureTimeHour,
+    dataToValidate.departureTimeMinute,
+  )) {
+    errors.departureTime = 'You must enter a departure time in the future';
+  } else if (isTimeAndDateBeforeNow(
     dataToValidate.departureDateYear,
     dataToValidate.departureDateMonth,
     dataToValidate.departureDateDay,
@@ -97,7 +105,15 @@ const VoyageFormValidation = async (dataToValidate, source) => {
     errors.departureDate = 'You must enter a departure time in the future';
   }
   // Arrival date must be in the future
-  if (isTimeAndDateBeforeNow(
+  if (isCurrentDateWithTimeBeforeNow(
+    dataToValidate.departureDateYear,
+    dataToValidate.departureDateMonth,
+    dataToValidate.departureDateDay,
+    dataToValidate.departureTimeHour,
+    dataToValidate.departureTimeMinute,
+  )) {
+    errors.departureTime = 'You must enter a departure time in the future';
+  } else if (isTimeAndDateBeforeNow(
     dataToValidate.arrivalDateYear,
     dataToValidate.arrivalDateMonth,
     dataToValidate.arrivalDateDay,

--- a/src/utils/__tests__/time.test.js
+++ b/src/utils/__tests__/time.test.js
@@ -1,4 +1,6 @@
-import { isTimeValid, isTimeAndDateBeforeNow, splitTime } from '../time';
+import {
+  isTimeValid, isCurrentDateWithTimeBeforeNow, isTimeAndDateBeforeNow, splitTime,
+} from '../time';
 
 describe('time.js', () => {
   it('should validate correct times', () => {
@@ -9,6 +11,12 @@ describe('time.js', () => {
   it('should not validate incorrect times', () => {
     const result = isTimeValid('08', '70');
     expect(result).toEqual(false);
+  });
+
+  it('should return true if the time is in the past but the date is current', () => {
+    const testDate = new Date();
+    const result = isCurrentDateWithTimeBeforeNow(testDate.getFullYear(), testDate.getMonth() + 1, testDate.getDate(), testDate.getHours(), testDate.getMinutes() - 5);
+    expect(result).toEqual(true);
   });
 
   it('should validate times before the current time', () => {

--- a/src/utils/__tests__/time.test.js
+++ b/src/utils/__tests__/time.test.js
@@ -1,5 +1,5 @@
 import {
-  isTimeValid, isCurrentDateWithTimeBeforeNow, isTimeAndDateBeforeNow, splitTime,
+  isTimeValid, isDateToday, isTimeAndDateBeforeNow, splitTime,
 } from '../time';
 
 describe('time.js', () => {
@@ -13,9 +13,9 @@ describe('time.js', () => {
     expect(result).toEqual(false);
   });
 
-  it('should return true if the time is in the past but the date is current', () => {
+  it('should return true if the date is current', () => {
     const testDate = new Date();
-    const result = isCurrentDateWithTimeBeforeNow(testDate.getFullYear(), testDate.getMonth() + 1, testDate.getDate(), testDate.getHours(), testDate.getMinutes() - 5);
+    const result = isDateToday(testDate.getFullYear(), testDate.getMonth() + 1, testDate.getDate());
     expect(result).toEqual(true);
   });
 

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -7,6 +7,21 @@ const isTimeValid = (hour, minute) => {
   return true;
 };
 
+const isCurrentDateWithTimeBeforeNow = (year, month, day, hour, minute) => {
+  const [currentDate, currentTime] = [1, 2].map(() => new Date());
+  const [testDate, testTime] = [1, 2].map(() => new Date(year, (month - 1), day, hour, minute));
+
+  currentDate.setHours(0, 0, 0, 0);
+  testDate.setHours(0, 0, 0, 0);
+  currentTime.setDate(0, 0, 0);
+  testTime.setDate(0, 0, 0);
+
+  if (currentDate.getTime() === testDate.getTime()) {
+    return currentTime.getTime() >= testTime.getTime();
+  }
+  return false;
+};
+
 const isTimeAndDateBeforeNow = (year, month, day, hour, minute) => {
   const today = new Date();
   const testDate = new Date(year, (month - 1), day, hour, minute);
@@ -20,6 +35,7 @@ const splitTime = (time, fieldName) => {
 
 export {
   isTimeValid,
+  isCurrentDateWithTimeBeforeNow,
   isTimeAndDateBeforeNow,
   splitTime,
 };

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -7,19 +7,15 @@ const isTimeValid = (hour, minute) => {
   return true;
 };
 
-const isCurrentDateWithTimeBeforeNow = (year, month, day, hour, minute) => {
-  const [currentDate, currentTime] = [1, 2].map(() => new Date());
-  const [testDate, testTime] = [1, 2].map(() => new Date(year, (month - 1), day, hour, minute));
+const isDateToday = (year, month, day) => {
+  const today = new Date();
+  const testDate = new Date(year, (month - 1), day);
 
-  currentDate.setHours(0, 0, 0, 0);
+  // Set the times to an equal value for a simpler date comparison with timestamps
+  today.setHours(0, 0, 0, 0);
   testDate.setHours(0, 0, 0, 0);
-  currentTime.setDate(0, 0, 0);
-  testTime.setDate(0, 0, 0);
 
-  if (currentDate.getTime() === testDate.getTime()) {
-    return currentTime.getTime() >= testTime.getTime();
-  }
-  return false;
+  return today.getTime() === testDate.getTime();
 };
 
 const isTimeAndDateBeforeNow = (year, month, day, hour, minute) => {
@@ -35,7 +31,7 @@ const splitTime = (time, fieldName) => {
 
 export {
   isTimeValid,
-  isCurrentDateWithTimeBeforeNow,
+  isDateToday,
   isTimeAndDateBeforeNow,
   splitTime,
 };


### PR DESCRIPTION
## Description
When a user types in the current date with a time in the past on a departure or arrival form, the error message previously popped up next to the date input as opposed to the time input where it should be, as the date is valid but the time is not. This PR fixes this issue.

## To Test
- Go to Voyage Plans Dashboard
- Start a new report
- Enter a date and time in the past
- Click Save and continue
- You should get an error on the date input
- Change the date to the current date while keeping the time before the current time
- Click Save and continue
- You should get an error on the time input
- Change the time to one in the future
- Click Save and continue
- You should not get errors on the date or time inputs

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [X] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
