### PR TITLE
SPCR-217 Add responsive tables for mobile

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -11,6 +11,10 @@
   vertical-align: middle;
 }
 
+.govuk-table__cell:last-child {
+  padding: 10px 20px 10px 0;
+}
+
 // Make block buttons display block
 .block-button {
   display: block;
@@ -34,4 +38,61 @@
 }
 .autocomplete__input--focused {
   outline: $govuk-focus-width solid $govuk-focus-colour;
+}
+
+.responsive-table {
+  margin-bottom: 0;
+  width: 100%;
+}
+
+tbody tr {
+  display: block;
+  margin-bottom: 1.5em;
+  padding: 0 0.5em;
+}
+
+@media (min-width: 769px) {
+  tbody tr {
+    display: table-row;
+  }
+}
+
+tbody tr td {
+  display: flex;
+  justify-content: space-between;
+  min-width: 1px;
+  text-align: right;
+}
+
+@media (max-width: 768px) {
+  tbody tr td {
+    padding-right: 0;
+  }
+  tbody tr td:last-child {
+    border-bottom: 0
+  }
+  tbody tr {
+    border-bottom: 3px solid grey;
+  }
+  thead {
+    display: none;
+  }
+}
+
+@media (min-width: 769px) {
+  tbody tr td {
+    display: table-cell;
+    text-align: left;
+  }
+}
+
+.responsive-table__heading {
+  font-weight: 700;
+  text-align: left;
+  word-break: initial;
+}
+@media (min-width: 769px) {
+  .responsive-table__heading {
+    display: none;
+  }
 }

--- a/src/components/ManageReports.jsx
+++ b/src/components/ManageReports.jsx
@@ -101,7 +101,7 @@ const ManageReports = (pageData) => {
             <h2 className="govuk-heading-l">{tableName}</h2>
             <table className="govuk-table">
               <thead className="govuk-table__head">
-                <tr className="govuk-table__row">
+                <tr className="govuk-table__row" role="row">
                   <th scope="col" className="govuk-table__header">Pleasure craft</th>
                   <th scope="col" className="govuk-table__header">Departure date</th>
                   <th scope="col" className="govuk-table__header">Departure port</th>
@@ -112,8 +112,11 @@ const ManageReports = (pageData) => {
                 {reportList && reportList.map((voyage) => {
                   if (voyage.status.name === tableName || voyage.status.name === `Pre${tableName}`) {
                     return (
-                      <tr className="govuk-table__row" key={voyage.id}>
-                        <td className="govuk-table__cell">
+                      <tr className="govuk-table__row" key={voyage.id} role="row">
+                        <td className="govuk-table__cell" role="cell">
+                          <span className="responsive-table__heading" aria-hidden="true">
+                            Pleasure craft
+                          </span>
                           <Link to={{
                             pathname: EDIT_VOYAGE_CHECK_DETAILS_URL,
                             state: { voyageId: voyage.id },
@@ -122,7 +125,10 @@ const ManageReports = (pageData) => {
                             {voyage.vesselName}
                           </Link>
                         </td>
-                        <td className="govuk-table__cell">
+                        <td className="govuk-table__cell" role="cell">
+                          <span className="responsive-table__heading" aria-hidden="true">
+                            Departure date
+                          </span>
                           <Link to={{
                             pathname: EDIT_VOYAGE_CHECK_DETAILS_URL,
                             state: { voyageId: voyage.id },
@@ -131,8 +137,18 @@ const ManageReports = (pageData) => {
                             {formatUIDate(voyage.departureDate)}
                           </Link>
                         </td>
-                        <td className="govuk-table__cell">{voyage.departurePort}</td>
-                        <td className="govuk-table__cell">{voyage.arrivalPort}</td>
+                        <td className="govuk-table__cell" role="cell">
+                          <span className="responsive-table__heading" aria-hidden="true">
+                            Departure port
+                          </span>
+                          {voyage.departurePort}
+                        </td>
+                        <td className="govuk-table__cell" role="cell">
+                          <span className="responsive-table__heading" aria-hidden="true">
+                            Arrival port
+                          </span>
+                          {voyage.arrivalPort}
+                        </td>
                       </tr>
                     );
                   }

--- a/src/components/SectionTablePeople.jsx
+++ b/src/components/SectionTablePeople.jsx
@@ -48,7 +48,7 @@ const SectionTablePeople = ({ pageData }) => {
             {!peopleData.errors && (
             <table className="govuk-table">
               <thead className="govuk-table__head">
-                <tr className="govuk-table__row">
+                <tr className="govuk-table__row" role="row">
                   {titles.map((elem) => {
                     return (
                       <th className="govuk-table__header" scope="col" key={elem}>{elem}</th>
@@ -59,8 +59,11 @@ const SectionTablePeople = ({ pageData }) => {
               <tbody className="govuk-table__body">
                 {Object.entries(peopleData).map((person) => {
                   return (
-                    <tr className="govuk-table__row" key={person[1].id}>
-                      <td className="govuk-table__cell">
+                    <tr className="govuk-table__row" key={person[1].id} role="row">
+                      <td className="govuk-table__cell" role="cell">
+                        <span className="responsive-table__heading" aria-hidden="true">
+                          Last Name
+                        </span>
                         <Link to={{
                           pathname: '/people/edit-person',
                           state: { peopleId: person[1].id },
@@ -69,8 +72,18 @@ const SectionTablePeople = ({ pageData }) => {
                           {person[1].lastName}
                         </Link>
                       </td>
-                      <td className="govuk-table__cell">{person[1].firstName}</td>
-                      <td className="govuk-table__cell">{getPersonType(person[1].peopleType.name)}</td>
+                      <td className="govuk-table__cell" role="cell">
+                        <span className="responsive-table__heading" aria-hidden="true">
+                          First Name
+                        </span>
+                        {person[1].firstName}
+                      </td>
+                      <td className="govuk-table__cell" role="cell">
+                        <span className="responsive-table__heading" aria-hidden="true">
+                          Type
+                        </span>
+                        {getPersonType(person[1].peopleType.name)}
+                      </td>
                     </tr>
                   );
                 })}

--- a/src/components/Vessel/VesselTable.jsx
+++ b/src/components/Vessel/VesselTable.jsx
@@ -7,7 +7,7 @@ const VesselTable = ({
   return (
     <table className="table-clickable govuk-table">
       <thead className="govuk-table__head">
-        <tr className="govuk-table__row">
+        <tr className="govuk-table__row" role="row">
           {checkboxes === 'true' && (
           <th className="govuk-table__header">
               &nbsp;
@@ -21,9 +21,9 @@ const VesselTable = ({
       <tbody className="govuk-table__body">
         {vesselData.map((vessel) => {
           return (
-            <tr className="govuk-table__row" key={vessel.id}>
+            <tr className="govuk-table__row" key={vessel.id} role="row">
               {checkboxes === 'true' && (
-              <td className="govuk-table__cell multiple-choice--hod">
+              <td className="govuk-table__cell multiple-choice--hod" role="cell">
                 <div className="govuk-checkboxes__item">
                   <input
                     type="checkbox"
@@ -38,15 +38,35 @@ const VesselTable = ({
               )}
               {link === 'true'
                 && (
-                <td className="govuk-table__cell">
+                <td className="govuk-table__cell" role="cell">
+                  <span className="responsive-table__heading" aria-hidden="true">
+                    Pleasure craft name
+                  </span>
                   <Link to={`/pleasure-crafts/${vessel.id}`}>
                     {vessel.vesselName}
                   </Link>
                 </td>
                 ) }
-              {link !== 'true' && <td className="govuk-table__cell">{vessel.vesselName}</td> }
-              <td className="govuk-table__cell">{vessel.vesselType}</td>
-              <td className="govuk-table__cell">{vessel.moorings}</td>
+              {link !== 'true' && (
+              <td className="govuk-table__cell" role="cell">
+                <span className="responsive-table__heading" aria-hidden="true">
+                  Pleasure craft name
+                </span>
+                {vessel.vesselName}
+              </td>
+              ) }
+              <td className="govuk-table__cell" role="cell">
+                <span className="responsive-table__heading" aria-hidden="true">
+                  Pleasure craft type
+                </span>
+                {vessel.vesselType}
+              </td>
+              <td className="govuk-table__cell" role="cell">
+                <span className="responsive-table__heading" aria-hidden="true">
+                  Usual moorings
+                </span>
+                {vessel.moorings}
+              </td>
             </tr>
           );
         })}

--- a/src/components/Voyage/PeopleSummary.jsx
+++ b/src/components/Voyage/PeopleSummary.jsx
@@ -31,7 +31,7 @@ const PeopleSummary = ({ voyageId, source }) => {
     <>
       <table className="govuk-table">
         <thead className="govuk-table__head">
-          <tr className="govuk-table__row">
+          <tr className="govuk-table__row" role="row">
             <th className="govuk-table__header" scope="col">Last name</th>
             <th className="govuk-table__header" scope="col">First name</th>
             <th className="govuk-table__header" scope="col">Date of birth</th>
@@ -43,40 +43,70 @@ const PeopleSummary = ({ voyageId, source }) => {
         {manifestData.map((person) => {
           return (
             <tbody className="govuk-table__body" key={person.id}>
-              <tr className="govuk-table__row">
-                <td className="govuk-table__cell">{person.lastName}</td>
-                <td className="govuk-table__cell">{person.firstName}</td>
-                <td className="govuk-table__cell">{formatUIDate(person.dateOfBirth)}</td>
-                <td className="govuk-table__cell">{person.documentNumber}</td>
-                <td className="govuk-table__cell">{person.nationality}</td>
-                <td className="govuk-table__cell">{getPersonType(person.peopleType.name)}</td>
+              <tr className="govuk-table__row" role="row">
+                <td className="govuk-table__cell" role="cell">
+                  <span className="responsive-table__heading" aria-hidden="true">
+                    Last name
+                  </span>
+                  {person.lastName}
+                </td>
+                <td className="govuk-table__cell" role="cell">
+                  <span className="responsive-table__heading" aria-hidden="true">
+                    First name
+                  </span>
+                  {person.firstName}
+                </td>
+                <td className="govuk-table__cell" role="cell">
+                  <span className="responsive-table__heading" aria-hidden="true">
+                    Date of birth
+                  </span>
+                  {formatUIDate(person.dateOfBirth)}
+                </td>
+                <td className="govuk-table__cell" role="cell">
+                  <span className="responsive-table__heading" aria-hidden="true">
+                    Travel document number
+                  </span>
+                  {person.documentNumber}
+                </td>
+                <td className="govuk-table__cell" role="cell">
+                  <span className="responsive-table__heading" aria-hidden="true">
+                    Nationality
+                  </span>
+                  {person.nationality}
+                </td>
+                <td className="govuk-table__cell" role="cell">
+                  <span className="responsive-table__heading" aria-hidden="true">
+                    Type
+                  </span>
+                  {getPersonType(person.peopleType.name)}
+                </td>
               </tr>
 
-              <tr className="govuk-table__row">
-                <td className="govuk-table__cell" colSpan={6}>
+              <tr className="govuk-table__row" role="row">
+                <td className="govuk-table__cell" colSpan={6} role="cell">
                   <div>
                     <Details summary="Further information">
                       <table className="govuk-table" width="100%">
                         <tbody className="govuk-table__body">
-                          <tr className="govuk-table__row">
-                            <td className="govuk-table__cell">Gender</td>
-                            <td className="govuk-table__cell">{(person.gender).charAt(0).toUpperCase() + person.gender.slice(1)}</td>
+                          <tr className="govuk-table__row" role="row">
+                            <td className="govuk-table__cell" role="cell">Gender</td>
+                            <td className="govuk-table__cell" role="cell">{(person.gender).charAt(0).toUpperCase() + person.gender.slice(1)}</td>
                           </tr>
-                          <tr className="govuk-table__row">
-                            <td className="govuk-table__cell">Place of birth</td>
-                            <td className="govuk-table__cell">{person.placeOfBirth}</td>
+                          <tr className="govuk-table__row" role="row">
+                            <td className="govuk-table__cell" role="cell">Place of birth</td>
+                            <td className="govuk-table__cell" role="cell">{person.placeOfBirth}</td>
                           </tr>
-                          <tr className="govuk-table__row">
-                            <td className="govuk-table__cell">Travel document type</td>
-                            <td className="govuk-table__cell">{person.documentType}</td>
+                          <tr className="govuk-table__row" role="row">
+                            <td className="govuk-table__cell" role="cell">Travel document type</td>
+                            <td className="govuk-table__cell" role="cell">{person.documentType}</td>
                           </tr>
-                          <tr className="govuk-table__row">
-                            <td className="govuk-table__cell">Travel document issuing state</td>
-                            <td className="govuk-table__cell">{person.documentIssuingState}</td>
+                          <tr className="govuk-table__row" role="row">
+                            <td className="govuk-table__cell" role="cell">Travel document issuing state</td>
+                            <td className="govuk-table__cell" role="cell">{person.documentIssuingState}</td>
                           </tr>
-                          <tr className="govuk-table__row">
-                            <td className="govuk-table__cell">Travel document expiry date</td>
-                            <td className="govuk-table__cell">{formatUIDate(person.documentExpiryDate)}</td>
+                          <tr className="govuk-table__row" role="row">
+                            <td className="govuk-table__cell" role="cell">Travel document expiry date</td>
+                            <td className="govuk-table__cell" role="cell">{formatUIDate(person.documentExpiryDate)}</td>
                           </tr>
                         </tbody>
                       </table>

--- a/src/components/Voyage/PeopleTable.jsx
+++ b/src/components/Voyage/PeopleTable.jsx
@@ -20,7 +20,7 @@ const PeopleTable = ({ peopleData, onSelectionChange = () => {} }) => {
   return (
     <table className="table-clickable govuk-table">
       <thead className="govuk-table__head">
-        <tr className="govuk-table__row">
+        <tr className="govuk-table__row" role="row">
           <th
             width={1}
             className="govuk-table__header  multiple-choice--hod"
@@ -33,8 +33,8 @@ const PeopleTable = ({ peopleData, onSelectionChange = () => {} }) => {
       <tbody className="govuk-table__body">
         {peopleData.map((person) => {
           return (
-            <tr className="govuk-table__row" key={person.id}>
-              <td className="govuk-table__cell multiple-choice--hod">
+            <tr className="govuk-table__row" key={person.id} role="row">
+              <td className="govuk-table__cell multiple-choice--hod" role="cell">
                 <div className="govuk-checkboxes__item">
                   <input
                     type="checkbox"
@@ -47,8 +47,18 @@ const PeopleTable = ({ peopleData, onSelectionChange = () => {} }) => {
                   <label className="govuk-label govuk-checkboxes__label" htmlFor={person.id}>&nbsp;</label>
                 </div>
               </td>
-              <td className="govuk-table__cell">{person.lastName}</td>
-              <td className="govuk-table__cell">{person.firstName}</td>
+              <td className="govuk-table__cell" role="cell">
+                <span className="responsive-table__heading" aria-hidden="true">
+                  Last name
+                </span>
+                {person.lastName}
+              </td>
+              <td className="govuk-table__cell" role="cell">
+                <span className="responsive-table__heading" aria-hidden="true">
+                  Pleasure craft type
+                </span>
+                {person.firstName}
+              </td>
             </tr>
           );
         })}


### PR DESCRIPTION
## Description
Update the tables across the service to be responsive without compromising on accessibility, by using the guide from [GitHub - Fenwick17/responsive-accessible-table](https://github.com/Fenwick17/responsive-accessible-table)

## To Test
- Go to a page with a table (Voyage Plans, Pleasure Crafts, People, Check your answers)
- Switch to a mobile screen
- The table layout should change to a more mobile-friendly one

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
