### PR TITLE
SPCR-248 Fix checkbox layout in responsive tables

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -96,3 +96,7 @@ tbody tr td {
     display: none;
   }
 }
+
+.govuk-checkboxes__item {
+  padding-left: 5px; 
+}

--- a/src/components/Voyage/PeopleTable.jsx
+++ b/src/components/Voyage/PeopleTable.jsx
@@ -35,6 +35,9 @@ const PeopleTable = ({ peopleData, onSelectionChange = () => {} }) => {
           return (
             <tr className="govuk-table__row" key={person.id} role="row">
               <td className="govuk-table__cell multiple-choice--hod" role="cell">
+                <span className="responsive-table__heading" aria-hidden="true">
+                  (Tick to select)
+                </span>
                 <div className="govuk-checkboxes__item">
                   <input
                     type="checkbox"
@@ -55,7 +58,7 @@ const PeopleTable = ({ peopleData, onSelectionChange = () => {} }) => {
               </td>
               <td className="govuk-table__cell" role="cell">
                 <span className="responsive-table__heading" aria-hidden="true">
-                  Pleasure craft type
+                  First name
                 </span>
                 {person.firstName}
               </td>


### PR DESCRIPTION
## Description
The positioning of the check box in mobile view when viewing the responsive tables should be fixed as it was placed in an odd position.

## To Test
- Go through the voyage form
- Go to the people on board page
- Add a new person on board
- Switch to a mobile view
- The table should look like the screenshot below 

<img width="411" alt="Screenshot 2022-02-11 at 13 41 37" src="https://user-images.githubusercontent.com/56563329/153605626-2b7a2cca-3ef2-431b-b72c-3c6b1dfa8cb4.png">

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
