### PR TITLE
SPCR-10 Add help/voyage start page

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -62,7 +62,7 @@ const Dashboard = (pageData) => {
             type="button"
             className="govuk-button govuk-button--start"
             data-module="govuk-button"
-            onClick={handleStart}
+            onClick={() => history.push('/voyage-plans/start')}
           >
             Start now
             <svg

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -2,8 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 
 import { USER_VOYAGE_REPORT_URL, VOYAGE_REPORT_URL } from '../constants/ApiConstants';
-import { SAVE_VOYAGE_DEPARTURE_URL } from '../constants/ClientConstants';
-import { deleteItem, getData, postData } from '../utils/apiHooks';
+import { deleteItem, getData } from '../utils/apiHooks';
 
 const Dashboard = (pageData) => {
   document.title = 'Voyage plans';
@@ -26,14 +25,6 @@ const Dashboard = (pageData) => {
           setReportList(validReports);
         }
       });
-  };
-
-  const handleStart = async () => {
-    const resp = await postData(USER_VOYAGE_REPORT_URL, null, 'reports');
-    history.push({
-      pathname: SAVE_VOYAGE_DEPARTURE_URL,
-      state: { voyageId: resp.id },
-    });
   };
 
   const countVoyages = (currentStatus) => {

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -8,6 +8,8 @@ import {
 import ScrollToTop from './ScrollToTop';
 import SecureRoute from '../lib/SecureRoute';
 
+import VoyageHelp from '../pages/help/Help';
+
 import Banner from './Banner';
 import Footer from './Footer';
 import Header from './Header';
@@ -65,6 +67,12 @@ const Main = () => {
             <Route exact path="/">
               <LandingPage />
             </Route>
+            <SecureRoute exact path="/page/help">
+              <VoyageHelp />
+            </SecureRoute>
+            <SecureRoute exact path="/voyage-plans/start">
+              <VoyageHelp />
+            </SecureRoute>
             <SecureRoute exact path="/voyage-plans">
               <PageContainer />
             </SecureRoute>

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -71,7 +71,7 @@ const Main = () => {
               <VoyageHelp />
             </SecureRoute>
             <SecureRoute exact path="/voyage-plans/start">
-              <VoyageHelp />
+              <VoyageHelp source="voyage" />
             </SecureRoute>
             <SecureRoute exact path="/voyage-plans">
               <PageContainer />

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -39,6 +39,11 @@ const Nav = () => {
       text: 'Account',
       active: false,
     },
+    {
+      urlStem: '/page/help',
+      text: 'Help',
+      active: false,
+    },
   ];
 
   const setActivePage = (url) => {

--- a/src/pages/help/Help.jsx
+++ b/src/pages/help/Help.jsx
@@ -52,7 +52,7 @@ const Help = ({ source }) => {
                 <li>Central: +44 (0)300 072 4322</li>
               </ul>
               {source === 'voyage' && (
-                <>
+                <div className="govuk-button-group">
                   <button
                     title="saveButton"
                     type="button"
@@ -71,7 +71,7 @@ const Help = ({ source }) => {
                   >
                     Cancel
                   </button>
-                </>
+                </div>
               )}
             </div>
           </div>

--- a/src/pages/help/Help.jsx
+++ b/src/pages/help/Help.jsx
@@ -29,13 +29,12 @@ const Help = ({ source }) => {
                 hours before you depart, but no more than 24 hours before you depart.
               </p>
               <p className="govuk-body">
-                We&apos;ll ask you when you plan to depart and arrive, and where from. You can enter a time range of up to 6 hours for your intended departure and arrival times.
+                We&apos;ll ask you when you plan to depart and arrive, and where from. You can enter a time range of up to 1 hour for your intended departure and arrival times.
               </p>
               <h2 className="govuk-heading-s">If your voyage plan changes</h2>
               <p className="govuk-body">We expect you to update your voyage plan for our records, as soon as possible.</p>
               <p className="govuk-body">
-                This includes changes to the date, departure or arrival point, people on board and significant changes to your intended departure or arrival time
-                (where these change by more than six hours).
+                This includes changes to the date, departure or arrival point, people on board and significant changes to your intended departure or arrival time.
               </p>
               <p className="govuk-body">You can sign into your account to change the voyage plan you submitted.</p>
               <h3 className="govuk-heading-s">

--- a/src/pages/help/Help.jsx
+++ b/src/pages/help/Help.jsx
@@ -1,7 +1,23 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 
-const Help = (source) => {
-  document.title = 'Help';
+import { USER_VOYAGE_REPORT_URL } from '../../constants/ApiConstants';
+import { SAVE_VOYAGE_DEPARTURE_URL } from '../../constants/ClientConstants';
+import { postData } from '../../utils/apiHooks';
+
+const Help = () => {
+  document.title = 'Telling us about your voyage plan';
+  const history = useHistory();
+
+  const source = 'voyage'
+
+  const handleStart = async () => {
+    const resp = await postData(USER_VOYAGE_REPORT_URL, null, 'reports');
+    history.push({
+      pathname: SAVE_VOYAGE_DEPARTURE_URL,
+      state: { voyageId: resp.id },
+    });
+  };
 
   return (
     <div className="govuk-width-container ">
@@ -45,19 +61,28 @@ const Help = (source) => {
                 <li>Central: +44 (0)300 072 4322</li>
               </ul>
               {source === 'voyage' && (
-              <form action="create-voyage-plan-departure">
-                <div className="govuk-button-group">
-                  <button type="submit" className="govuk-button" data-module="govuk-button">
-                    Continue
+                <>
+                  <button
+                    title="saveButton"
+                    type="button"
+                    className="govuk-button"
+                    data-module="govuk-button"
+                    onClick={handleStart}
+                  >
+                    Save and continue
                   </button>
-                  <a href="home.html" className="govuk-button govuk-button--secondary" data-module="govuk-button">
+                  <button
+                    title="cancelButton"
+                    type="button"
+                    className="govuk-button govuk-button--secondary"
+                    data-module="govuk-button"
+                    onClick={() => history.push('/voyage-plans')}
+                  >
                     Cancel
-                  </a>
-                </div>
-              </form>
+                  </button>
+                </>
               )}
             </div>
-            <div className="govuk-grid-column-one-third" />
           </div>
         </div>
       </main>

--- a/src/pages/help/Help.jsx
+++ b/src/pages/help/Help.jsx
@@ -5,11 +5,9 @@ import { USER_VOYAGE_REPORT_URL } from '../../constants/ApiConstants';
 import { SAVE_VOYAGE_DEPARTURE_URL } from '../../constants/ClientConstants';
 import { postData } from '../../utils/apiHooks';
 
-const Help = () => {
+const Help = ({ source }) => {
   document.title = 'Telling us about your voyage plan';
   const history = useHistory();
-
-  const source = 'voyage'
 
   const handleStart = async () => {
     const resp = await postData(USER_VOYAGE_REPORT_URL, null, 'reports');
@@ -31,25 +29,18 @@ const Help = () => {
                 hours before you depart, but no more than 24 hours before you depart.
               </p>
               <p className="govuk-body">
-                We&apos;ll ask you when you plan to depart and arrive, and where from. You can enter a
-                time range of up to 6 hours for your intended departure and arrival times.
+                We&apos;ll ask you when you plan to depart and arrive, and where from. You can enter a time range of up to 6 hours for your intended departure and arrival times.
               </p>
               <h2 className="govuk-heading-s">If your voyage plan changes</h2>
               <p className="govuk-body">We expect you to update your voyage plan for our records, as soon as possible.</p>
               <p className="govuk-body">
-                This includes changes to the date, departure or arrival point, people on board and
-                significant changes to your intended departure or arrival time (where these change by more than six
-                hours).
+                This includes changes to the date, departure or arrival point, people on board and significant changes to your intended departure or arrival time
+                (where these change by more than six hours).
               </p>
               <p className="govuk-body">You can sign into your account to change the voyage plan you submitted.</p>
               <h3 className="govuk-heading-s">
-                In an emergency, or if you can’t update your account online, you should call
-                Border Force as soon as possible.
+                In an emergency, or if you can&apos;t update your account online, you should call Border Force as soon as possible.
               </h3>
-              <p className="govuk-body">
-                The number which you call depends upon which UK region you arrive to or depart
-                from:
-              </p>
               <p className="govuk-body">
                 The number which you call depends upon which UK region you arrive to or depart
                 from:
@@ -69,7 +60,7 @@ const Help = () => {
                     data-module="govuk-button"
                     onClick={handleStart}
                   >
-                    Save and continue
+                    Continue
                   </button>
                   <button
                     title="cancelButton"

--- a/src/pages/help/Help.jsx
+++ b/src/pages/help/Help.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+const Help = (source) => {
+  document.title = 'Help';
+
+  return (
+    <div className="govuk-width-container ">
+      <main className="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+        <div className="govuk-width-container">
+          <div className="govuk-grid-row">
+            <div className="govuk-grid-column-two-thirds">
+              <h1 className="govuk-heading-l">Telling us about your voyage plan</h1>
+              <p className="govuk-body-l">
+                You can draft a voyage plan anytime. You should submit your plan at least two
+                hours before you depart, but no more than 24 hours before you depart.
+              </p>
+              <p className="govuk-body">
+                We&apos;ll ask you when you plan to depart and arrive, and where from. You can enter a
+                time range of up to 6 hours for your intended departure and arrival times.
+              </p>
+              <h2 className="govuk-heading-s">If your voyage plan changes</h2>
+              <p className="govuk-body">We expect you to update your voyage plan for our records, as soon as possible.</p>
+              <p className="govuk-body">
+                This includes changes to the date, departure or arrival point, people on board and
+                significant changes to your intended departure or arrival time (where these change by more than six
+                hours).
+              </p>
+              <p className="govuk-body">You can sign into your account to change the voyage plan you submitted.</p>
+              <h3 className="govuk-heading-s">
+                In an emergency, or if you can’t update your account online, you should call
+                Border Force as soon as possible.
+              </h3>
+              <p className="govuk-body">
+                The number which you call depends upon which UK region you arrive to or depart
+                from:
+              </p>
+              <p className="govuk-body">
+                The number which you call depends upon which UK region you arrive to or depart
+                from:
+              </p>
+              <ul className="govuk-list govuk-list--bullet">
+                <li>South: +44 (0)1293 501266</li>
+                <li>South East: +44 (0)130 329 9157</li>
+                <li>North: +44 (0)300 106 5725</li>
+                <li>Central: +44 (0)300 072 4322</li>
+              </ul>
+              {source === 'voyage' && (
+              <form action="create-voyage-plan-departure">
+                <div className="govuk-button-group">
+                  <button type="submit" className="govuk-button" data-module="govuk-button">
+                    Continue
+                  </button>
+                  <a href="home.html" className="govuk-button govuk-button--secondary" data-module="govuk-button">
+                    Cancel
+                  </a>
+                </div>
+              </form>
+              )}
+            </div>
+            <div className="govuk-grid-column-one-third" />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default Help;

--- a/src/pages/help/__tests__/Help.test.jsx
+++ b/src/pages/help/__tests__/Help.test.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import Help from '../Help';
+
+test('Renders the help with the CTAs for the voyage form', () => {
+  render(<Help source="voyage" />);
+
+  const contentH1 = screen.getByText('Telling us about your voyage plan');
+  expect(contentH1.outerHTML).toEqual('<h1 class="govuk-heading-l">Telling us about your voyage plan</h1>');
+  expect(screen.getByText(
+    'You can draft a voyage plan anytime. You should submit your plan at least two hours before you depart, but no more than 24 hours before you depart.',
+  )).toBeInTheDocument();
+  expect(screen.getByText(
+    'We\'ll ask you when you plan to depart and arrive, and where from. You can enter a time range of up to 6 hours for your intended departure and arrival times.',
+  )).toBeInTheDocument();
+
+  const contentH2 = screen.getByText('If your voyage plan changes');
+  expect(contentH2.outerHTML).toEqual('<h2 class="govuk-heading-s">If your voyage plan changes</h2>');
+  expect(screen.getByText(
+    'We expect you to update your voyage plan for our records, as soon as possible.',
+  )).toBeInTheDocument();
+  expect(screen.getByText(
+    'This includes changes to the date, departure or arrival point, people on board and significant changes to your intended departure or arrival time'
+    + ' (where these change by more than six hours).',
+  )).toBeInTheDocument();
+  expect(screen.getByText('You can sign into your account to change the voyage plan you submitted.')).toBeInTheDocument();
+
+  const contentH3 = screen.getByText(
+    'In an emergency, or if you can\'t update your account online, you should call Border Force as soon as possible.',
+  );
+  expect(contentH3.outerHTML).toEqual(
+    '<h3 class="govuk-heading-s">In an emergency, or if you can\'t update your account online, you should call Border Force as soon as possible.</h3>',
+  );
+  expect(screen.getByText('The number which you call depends upon which UK region you arrive to or depart from:')).toBeInTheDocument();
+  expect(screen.getByText('South: +44 (0)1293 501266')).toBeInTheDocument();
+  expect(screen.getByText('South East: +44 (0)130 329 9157')).toBeInTheDocument();
+  expect(screen.getByText('North: +44 (0)300 106 5725')).toBeInTheDocument();
+  expect(screen.getByText('Central: +44 (0)300 072 4322')).toBeInTheDocument();
+
+  const primaryButton = screen.getByTitle('saveButton');
+  expect(primaryButton).toHaveTextContent('Continue');
+  expect(primaryButton.outerHTML).toEqual(
+    '<button title="saveButton" type="button" class="govuk-button" data-module="govuk-button">Continue</button>',
+  );
+
+  const secondaryButton = screen.getByTitle('cancelButton');
+  expect(secondaryButton).toHaveTextContent('Cancel');
+  expect(secondaryButton.outerHTML).toEqual(
+    '<button title="cancelButton" type="button" class="govuk-button govuk-button--secondary" data-module="govuk-button">Cancel</button>',
+  );
+});

--- a/src/pages/help/__tests__/Help.test.jsx
+++ b/src/pages/help/__tests__/Help.test.jsx
@@ -12,7 +12,7 @@ test('Renders the help with the CTAs for the voyage form', () => {
     'You can draft a voyage plan anytime. You should submit your plan at least two hours before you depart, but no more than 24 hours before you depart.',
   )).toBeInTheDocument();
   expect(screen.getByText(
-    'We\'ll ask you when you plan to depart and arrive, and where from. You can enter a time range of up to 6 hours for your intended departure and arrival times.',
+    'We\'ll ask you when you plan to depart and arrive, and where from. You can enter a time range of up to 1 hour for your intended departure and arrival times.',
   )).toBeInTheDocument();
 
   const contentH2 = screen.getByText('If your voyage plan changes');
@@ -21,8 +21,7 @@ test('Renders the help with the CTAs for the voyage form', () => {
     'We expect you to update your voyage plan for our records, as soon as possible.',
   )).toBeInTheDocument();
   expect(screen.getByText(
-    'This includes changes to the date, departure or arrival point, people on board and significant changes to your intended departure or arrival time'
-    + ' (where these change by more than six hours).',
+    'This includes changes to the date, departure or arrival point, people on board and significant changes to your intended departure or arrival time.',
   )).toBeInTheDocument();
   expect(screen.getByText('You can sign into your account to change the voyage plan you submitted.')).toBeInTheDocument();
 


### PR DESCRIPTION
## Description

- add help page
- use help page as first page in voyage journey
- hide continue/cancel buttons if viewing help page from anywhere other than voyage start

## To test

- log in
- start a voyage
- > first page should be new help page
- click cancel
- > you should be returned to the dashboard
- start another voyage
- click continue
- > departure details page should load
- complete this page and continue
- return to dashboard
- view voyage plans
- > the plan you just started should be visible in the draft list


## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

-  [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
