### PR TITLE
SPCR-243 Remove actions that allow user to cancel a cancelled voyage

### DIFF
--- a/src/components/Voyage/FormCheck.jsx
+++ b/src/components/Voyage/FormCheck.jsx
@@ -211,24 +211,30 @@ const FormCheck = ({
         </Link>
       </div>
 
-      <h2 className="govuk-heading-m">Submit your Pleasure Craft Voyage Plan</h2>
-      <p className="govuk-body">
-        By submitting this voyage plan you are confirming that, to the best of your knowledge,
-        the information you are providing is correct and you have the explicit permission of the persons named in this voyage plan to submit information on their behalf.
-      </p>
-      <div id="submitBlock" className="govuk-button-group">
-        <button
-          type="button"
-          className="govuk-button"
-          data-module="govuk-button"
-          onClick={(e) => handleSubmit(e, 'check', voyageId)}
-        >
-          Accept and submit voyage plan
-        </button>
-        <Link className="govuk-button govuk-button--warning" to={`/voyage-plans/${voyageId}/delete`}>
-          Cancel voyage plan
-        </Link>
-      </div>
+      {voyageData.status.name !== 'Cancelled' && voyageData.status.name !== 'PreCancelled'
+        && (
+        <>
+          <h2 className="govuk-heading-m">Submit your Pleasure Craft Voyage Plan</h2>
+          <p className="govuk-body">
+            By submitting this voyage plan you are confirming that, to the best of your knowledge,
+            the information you are providing is correct and you have the explicit permission of the persons named in this voyage plan to submit information on their behalf.
+          </p>
+
+          <div id="submitBlock" className="govuk-button-group">
+            <button
+              type="button"
+              className="govuk-button"
+              data-module="govuk-button"
+              onClick={(e) => handleSubmit(e, 'check', voyageId)}
+            >
+              Accept and submit voyage plan
+            </button>
+            <Link className="govuk-button govuk-button--warning" to={`/voyage-plans/${voyageId}/delete`}>
+              Cancel voyage plan
+            </Link>
+          </div>
+        </>
+        )}
     </section>
   );
 };

--- a/src/components/Voyage/VoyageFormContainer.jsx
+++ b/src/components/Voyage/VoyageFormContainer.jsx
@@ -373,11 +373,13 @@ const FormVoyageContainer = () => {
                 />
               )}
             </form>
-            <p className="govuk-body">
-              <Link to="/voyage-plans" className="govuk-link govuk-link--no-visited-state">
-                Exit without saving
-              </Link>
-            </p>
+            {pageNum === 7 && voyageData && (voyageData.status.name === 'Cancelled' || voyageData.status.name !== 'PreCancelled') ? null : (
+              <p className="govuk-body">
+                <Link to="/voyage-plans" className="govuk-link govuk-link--no-visited-state">
+                  Exit without saving
+                </Link>
+              </p>
+            )}
           </div>
         </div>
       </main>

--- a/src/components/Voyage/__tests__/FormCheck.test.jsx
+++ b/src/components/Voyage/__tests__/FormCheck.test.jsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import FormCheck from '../FormCheck';
+
+let mockHandleSubmit = jest.fn();
+
+const renderPage = (props = {
+  voyageData: {
+    arrivalDate: '2022-06-06',
+    arrivalDateDay: '06',
+    arrivalDateMonth: '06',
+    arrivalDateYear: '2022',
+    arrivalPort: 'PME',
+    arrivalTime: '12:00:00',
+    arrivalTimeHour: '12',
+    arrivalTimeMinute: '00',
+    departureDate: '2022-01-27',
+    departureDateDay: '27',
+    departureDateMonth: '01',
+    departureDateYear: '2022',
+    departurePort: 'DVR',
+    departureTime: '12:00:00',
+    departureTimeHour: '12',
+    departureTimeMinute: '00',
+    id: '1234',
+    moorings: 'Port ',
+    registration: 'Boat',
+    responsibleAddressLine1: 'Address',
+    responsibleContactNo: '12345678910',
+    responsibleCounty: 'County',
+    responsibleGivenName: 'John',
+    responsiblePostcode: 'A1B2C3D4',
+    responsibleSurname: 'Doe',
+    responsibleTown: 'Town',
+    status: { name: 'Draft' },
+    vesselName: 'Boat',
+    vesselType: 'Boat',
+  },
+  voyageId: '1234',
+  handleSubmit: mockHandleSubmit,
+  errors: {},
+}) => {
+  return render(
+    <MemoryRouter>
+      <FormCheck {...props} />
+    </MemoryRouter>,
+  );
+};
+
+describe('FormCheck', () => {
+  it('should render the page', () => {
+    renderPage();
+  });
+
+  it('should render the page without errors', () => {
+    renderPage();
+
+    expect(screen.getByText('Check the information provided before submitting your voyage plan')).toBeInTheDocument();
+    expect(screen.getByText('Departure details')).toBeInTheDocument()
+    expect(screen.getByText('27/01/2022')).toBeInTheDocument()
+    expect(screen.getByText('06/06/2022')).toBeInTheDocument()
+    expect(screen.getByText('Address, Town, County, A1B2C3D4')).toBeInTheDocument()
+    expect(screen.getByText('Cancel voyage plan')).toBeInTheDocument()
+    expect(screen.getByText('Accept and submit voyage plan')).toBeInTheDocument()
+
+  });
+
+  it('should call handleSubmit when submit is clicked', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByText('Accept and submit voyage plan'));
+    expect(mockHandleSubmit).toHaveBeenCalled()
+  });
+
+  it('should not render CTAs if report has a status of cancelled', () => {
+    renderPage({
+      voyageData: {
+        arrivalDate: '2022-06-06',
+        arrivalDateDay: '06',
+        arrivalDateMonth: '06',
+        arrivalDateYear: '2022',
+        arrivalPort: 'PME',
+        arrivalTime: '12:00:00',
+        arrivalTimeHour: '12',
+        arrivalTimeMinute: '00',
+        departureDate: '2022-01-27',
+        departureDateDay: '27',
+        departureDateMonth: '01',
+        departureDateYear: '2022',
+        departurePort: 'DVR',
+        departureTime: '12:00:00',
+        departureTimeHour: '12',
+        departureTimeMinute: '00',
+        id: '1234',
+        moorings: 'Port ',
+        registration: 'Boat',
+        responsibleAddressLine1: 'Address',
+        responsibleContactNo: '12345678910',
+        responsibleCounty: 'County',
+        responsibleGivenName: 'John',
+        responsiblePostcode: 'A1B2C3D4',
+        responsibleSurname: 'Doe',
+        responsibleTown: 'Town',
+        status: { name: 'Cancelled' },
+        vesselName: 'Boat',
+        vesselType: 'Boat',
+      },
+      voyageId: '1234',
+      handleSubmit: () => { },
+      errors: {}
+    })
+
+
+    expect(screen.queryByText('Accept and submit voyage plan')).not.toBeInTheDocument();
+    expect(screen.queryByText('Cancel voyage plan')).not.toBeInTheDocument();
+  });
+
+  it('should not render page when there is no voyage data', () => {
+    const { container } = renderPage({
+      voyageData: null,
+      voyageId: '1234',
+      handleSubmit: () => { },
+      errors: {}
+    })
+    // expect empty component
+    expect(container.childElementCount).toEqual(0);
+  });
+});


### PR DESCRIPTION
## Description
Currently if a voyage is of the state cancelled or precancelled, when a user views this voyage, the ‘check’ page has the option to submit, cancel and exit without saving. If a voyage is cancelled, these CTAs should not be visible. 

### To test

- Click on 'View existing voyage plans'
- Go to the cancelled tab
- (If there are no cancelled reports, make a report and cancel it)
- Click on a cancelled report
- Scroll to the bottom
- There should be no submit, cancel or exit without saving visible
- Drafts and Submitted reports should still have these CTAs (for now at least)

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [X] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
