### PR TITLE
SPCR-291 Increase the count of 'Submitted' reports in failure scenario

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -77,19 +77,19 @@ const Dashboard = (pageData) => {
           <div className="govuk-grid-row">
             <div className="govuk-grid-column-one-third panel-number">
               <p className="govuk-body-s">
-                <strong className="panel-number-large">{countVoyages('Draft')}</strong>
+                <strong className="panel-number-large" data-testid="draft-count">{countVoyages('Draft')}</strong>
                 Draft
               </p>
             </div>
             <div className="govuk-grid-column-one-third panel-number">
               <p className="govuk-body-s">
-                <strong className="panel-number-large">{countVoyages('PreSubmitted') + countVoyages('Submitted')}</strong>
+                <strong className="panel-number-large" data-testid="submitted-count">{countVoyages('PreSubmitted') + countVoyages('Submitted') + countVoyages('Failed')}</strong>
                 Submitted
               </p>
             </div>
             <div className="govuk-grid-column-one-third panel-number">
               <p className="govuk-body-s">
-                <strong className="panel-number-large">{countVoyages('Cancelled') + countVoyages('PreCancelled')}</strong>
+                <strong className="panel-number-large" data-testid="cancelled-count">{countVoyages('Cancelled') + countVoyages('PreCancelled')}</strong>
                 Cancelled
               </p>
             </div>

--- a/src/components/__tests__/Dashboard.test.jsx
+++ b/src/components/__tests__/Dashboard.test.jsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+} from '@testing-library/react';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+
+import Dashboard from '../Dashboard';
+import { USER_VOYAGE_REPORT_URL, VOYAGE_REPORT_URL } from '../../constants/ApiConstants';
+import { pageSizeParam } from '../../lib/config';
+
+const mockHistoryPush = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    push: mockHistoryPush,
+  }),
+  Link: ({ children }) => children,
+}));
+
+const renderPage = () => {
+  return render(
+    <Dashboard pageData="/voyage-plans" />,
+  );
+};
+
+describe('Dashboard', () => {
+  const mockAxios = new MockAdapter(axios);
+
+  beforeEach(() => {
+    mockAxios.reset();
+  });
+
+  it('should filter by status correctly', async () => {
+    mockAxios
+      .onGet(`${USER_VOYAGE_REPORT_URL}${pageSizeParam}`)
+      .reply(200, {
+        items: [
+          {
+            departureDate: '2022-12-30',
+            departurePort: 'GB BPT',
+            departureTime: '12:00:00',
+            id: '1',
+            status: {
+              name: 'Draft',
+            },
+          },
+          {
+            departureDate: '2022-12-30',
+            departurePort: 'GB BPT',
+            departureTime: '12:00:00',
+            id: '2',
+            status: {
+              name: 'Submitted',
+            },
+          },
+          {
+            departureDate: '2022-12-30',
+            departurePort: 'GB BPT',
+            departureTime: '12:00:00',
+            id: '3',
+            status: {
+              name: 'PreSubmitted',
+            },
+          },
+          {
+            departureDate: '2022-12-30',
+            departurePort: 'GB BPT',
+            departureTime: '12:00:00',
+            id: '4',
+            status: {
+              name: 'Cancelled',
+            },
+          },
+          {
+            departureDate: '2022-12-30',
+            departurePort: 'GB BPT',
+            departureTime: '12:00:00',
+            id: '5',
+            status: {
+              name: 'PreCancelled',
+            },
+          },
+          {
+            departureDate: '2022-12-30',
+            departurePort: 'GB BPT',
+            departureTime: '12:00:00',
+            id: '6',
+            status: {
+              name: 'Failed',
+            },
+          },
+        ],
+      });
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('draft-count')).toHaveTextContent(1);
+      // Count should include Submitted, PreSubmitted and Failed reports
+      expect(screen.getByTestId('submitted-count')).toHaveTextContent(3);
+      // Count should include Cancelled and PreCancelled
+      expect(screen.getByTestId('cancelled-count')).toHaveTextContent(2);
+    });
+  });
+
+  it('should delete voyage plan if departure data is missing', async () => {
+    mockAxios
+      .onGet(`${USER_VOYAGE_REPORT_URL}${pageSizeParam}`)
+      .reply(200, {
+        items: [
+          {
+            departureDate: '2022-12-30', departurePort: 'GB BPT', departureTime: '12:00:00', id: '1', status: { name: 'Draft' },
+          },
+          { id: '2', status: { name: 'Draft' } },
+        ],
+      });
+
+    mockAxios.onDelete(`${VOYAGE_REPORT_URL}/2`).reply(200);
+    renderPage();
+
+    await waitFor(() => {
+      expect(mockAxios.history.delete.length).toBe(1);
+      expect(screen.getByTestId('draft-count')).toHaveTextContent(1);
+    });
+  });
+
+  it('should redirect when a user clicks start now', async () => {
+    mockAxios
+      .onGet(`${USER_VOYAGE_REPORT_URL}${pageSizeParam}`)
+      .reply(200, {
+        items: [],
+      });
+
+    renderPage();
+
+    await waitFor(() => {
+      fireEvent.click(screen.getByText('Start now'));
+
+      expect(mockHistoryPush).toHaveBeenCalled();
+      expect(mockHistoryPush).toHaveBeenCalledWith('/voyage-plans/start');
+    });
+  });
+});


### PR DESCRIPTION
## Description
Currently, when a voyage plan is submitted but receives the status of `failed`, this voyage is not shown in the UI. The user should not know that the submission has failed, therefore we need the `submitted` counter to increase after a submitting a voyage plan, even if it has the status of failed. 

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [X] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
