### PR TITLE
SPCR-328 GET port list only after 3 characters typed for autosuggest field

### DIFF
--- a/src/components/PortField.jsx
+++ b/src/components/PortField.jsx
@@ -17,18 +17,19 @@ let ports = [];
 function fetchPorts(query) {
   if (query.length < 3) {
     ports = [];
-  }
-  axios.get(`${PORTS_URL}?name=${encodeURIComponent(query)}`, {
-    headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
-  })
-    .then((resp) => {
-      ports = resp.data;
+  } else {
+    axios.get(`${PORTS_URL}?name=${encodeURIComponent(query)}`, {
+      headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
     })
-    .catch((err) => {
-      if (err.response) {
-        ports = [];
-      }
-    });
+      .then((resp) => {
+        ports = resp.data;
+      })
+      .catch((err) => {
+        if (err.response) {
+          ports = [];
+        }
+      });
+  }
 }
 
 const PortField = ({


### PR DESCRIPTION
## Description
We were previously making GET calls on render
We want to only make a call once at least 3 letter are typed

## To Test
- Go to an autocomplete field (departure/arrival port form)
- Type one letter
- No suggestions or get calls are made
- Type two letters
- No suggestions or get calls are made
- Type three letters
- Get calls are made and suggestions are made if available

## Developer Checklist

\* Required

- [ ] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
