### PR TITLE
1.1.0 SPCR-288 Show port names as well as unlocodes

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -20,31 +20,6 @@
 .block-button {
   display: block;
 }
-// Style button like text links
-.govuk-button--text {
-  color: #1d70b8;
-  text-decoration: underline;
-  background-color: transparent;
-  box-shadow: none;
-  padding: 0;
-}
-.govuk-button--text:hover {
-  color: #003078;
-  background-color: transparent;
-  box-shadow: none;
-}
-.govuk-button--text:active {
-  color: #0b0c0c;
-  background-color: transparent;
-  box-shadow: none;
-}
-.govuk-button--text:focus {
-  outline: 3px solid transparent;
-  color: #0b0c0c;
-  background-color: #fd0;
-  box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
-  text-decoration: none;
-}
 
 .page-notice {
   color: #FFFFFF;

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -20,6 +20,31 @@
 .block-button {
   display: block;
 }
+// Style button like text links
+.govuk-button--text {
+  color: #1d70b8;
+  text-decoration: underline;
+  background-color: transparent;
+  box-shadow: none;
+  padding: 0;
+}
+.govuk-button--text:hover {
+  color: #003078;
+  background-color: transparent;
+  box-shadow: none;
+}
+.govuk-button--text:active {
+  color: #0b0c0c;
+  background-color: transparent;
+  box-shadow: none;
+}
+.govuk-button--text:focus {
+  outline: 3px solid transparent;
+  color: #0b0c0c;
+  background-color: #fd0;
+  box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+  text-decoration: none;
+}
 
 .page-notice {
   color: #FFFFFF;

--- a/src/components/ManageReports.jsx
+++ b/src/components/ManageReports.jsx
@@ -6,6 +6,7 @@ import { EDIT_VOYAGE_CHECK_DETAILS_URL } from '../constants/ClientConstants';
 import { pageSizeParam } from '../lib/config';
 import { deleteItem, getData } from '../utils/apiHooks';
 import { formatUIDate } from '../utils/date';
+import formatPortValue from '../utils/formatPortData';
 import Pagination from './Pagination';
 import LoadingSpinner from './LoadingSpinner';
 

--- a/src/components/ManageReports.jsx
+++ b/src/components/ManageReports.jsx
@@ -70,9 +70,10 @@ const ManageReports = (pageData) => {
       });
   };
 
-  // Sets tab data on load
+  // Sets tab data on load & ensures session data clear
   useEffect(() => {
     setTabData(tabs);
+    sessionStorage.removeItem('formData');
   }, [pageData]);
 
   // Calls api whenever current page changes

--- a/src/components/ManageReports.jsx
+++ b/src/components/ManageReports.jsx
@@ -6,7 +6,6 @@ import { EDIT_VOYAGE_CHECK_DETAILS_URL } from '../constants/ClientConstants';
 import { pageSizeParam } from '../lib/config';
 import { deleteItem, getData } from '../utils/apiHooks';
 import { formatUIDate } from '../utils/date';
-import formatPortValue from '../utils/formatPortData';
 import Pagination from './Pagination';
 import LoadingSpinner from './LoadingSpinner';
 

--- a/src/components/PortField.jsx
+++ b/src/components/PortField.jsx
@@ -12,30 +12,29 @@ import {
 import { PORTS_URL } from '../constants/ApiConstants';
 import Auth from '../lib/Auth';
 
-let ports = [];
-
-function fetchPorts(query) {
-  if (query.length >= 2) {
-    axios.get(`${PORTS_URL}?name=${encodeURIComponent(query)}`, {
-      headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
-    })
-      .then((resp) => {
-        ports = resp.data;
-      })
-      .catch((err) => {
-        if (err.response) {
-          ports = [];
-        }
-      });
-  }
-}
-
 const PortField = ({
-  onConfirm = () => {}, fieldName, defaultValue = '', ...props
+  onConfirm = () => {}, fieldName, defaultValue, ...props
 }) => {
+  const [portList, setPortList] = useState([]);
   const [portEntered, setPortEntered] = useState('');
-  const [searchTerm, setSearchTerm] = useState(defaultValue || '');
+  const [searchTerm, setSearchTerm] = useState('');
   const [otherValue, setOtherValue] = useState('');
+
+  const fetchPorts = (query) => {
+    if (query.length >= 2) {
+      axios.get(`${PORTS_URL}?name=${encodeURIComponent(query)}`, {
+        headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
+      })
+        .then((resp) => {
+          setPortList(resp.data);
+        })
+        .catch((err) => {
+          if (err.response) {
+            setPortList([]);
+          }
+        });
+    }
+  };
 
   const handleSearchTermChange = (event) => {
     setSearchTerm(event.target.value);
@@ -65,9 +64,19 @@ const PortField = ({
     togglePortField(true);
   };
 
+  const clearInput = (e) => {
+    e.target.value = '';
+  };
+
   useEffect(() => {
     onConfirm(portEntered);
   }, [portEntered]);
+
+  useEffect(() => {
+    setSearchTerm(defaultValue);
+  }, [defaultValue]);
+
+  console.log(portList);
 
   return (
     <>
@@ -84,12 +93,13 @@ const PortField = ({
           data-testid="port"
           onChange={handleSearchTermChange}
           value={searchTerm}
+          onFocus={(e) => clearInput(e)}
         />
-        {ports && (
+        {portList.length > 0 && (
           <ComboboxPopover className="shadow-popup">
-            {ports.length > 0 ? (
+            {portList.length > 0 ? (
               <ComboboxList className="comboBoxListItem">
-                {ports.slice(0, 10).map((port) => {
+                {portList.slice(0, 10).map((port) => {
                   const str = port.unlocode === '' ? `${port.name}` : `${port.name} (${port.unlocode})`;
                   return <ComboboxOption role="option" key={str} value={str} />;
                 })}

--- a/src/components/PortField.jsx
+++ b/src/components/PortField.jsx
@@ -70,7 +70,7 @@ const PortField = ({
   }, [portEntered]);
 
   useEffect(() => {
-    setSearchTerm(defaultValue);
+    setSearchTerm(defaultValue || '');
   }, [defaultValue]);
 
   return (
@@ -94,7 +94,7 @@ const PortField = ({
             {portList.length > 0 ? (
               <ComboboxList className="comboBoxListItem">
                 {portList.slice(0, 10).map((port) => {
-                  const str = port.unlocode === '' ? `${port.name}` : `${port.name} (${port.unlocode})`;
+                  const str = port.unlocode === '' ? `${port?.name}` : `${port.name} (${port.unlocode})`;
                   return <ComboboxOption role="option" key={str} value={str} />;
                 })}
               </ComboboxList>

--- a/src/components/PortField.jsx
+++ b/src/components/PortField.jsx
@@ -13,7 +13,7 @@ import { PORTS_URL } from '../constants/ApiConstants';
 import Auth from '../lib/Auth';
 
 const PortField = ({
-  onConfirm = () => {}, fieldName, defaultValue, ...props
+  onConfirm = () => {}, fieldName, defaultValue,
 }) => {
   const [portList, setPortList] = useState([]);
   const [portEntered, setPortEntered] = useState('');
@@ -80,12 +80,12 @@ const PortField = ({
         data-testid="portContainer"
         aria-label="Ports"
         onSelect={(e) => handlePortSelection(e)}
-        name={fieldName}
-        {...props}
       >
         <ComboboxInput
+          id="autocomplete"
           className="govuk-input"
           data-testid="port"
+          name={`autocomplete${fieldName}`}
           onChange={handleSearchTermChange}
           value={searchTerm}
         />

--- a/src/components/PortField.jsx
+++ b/src/components/PortField.jsx
@@ -41,11 +41,12 @@ const PortField = ({
     fetchPorts(event.target.value);
   };
 
-  const togglePortField = (other, value) => {
-    if (other) {
-      setOtherValue('');
+  const togglePortField = (isSelectorField, value) => {
+    if (isSelectorField) {
+      setOtherValue(''); // user selects from the autoselect
+      setPortList([]);
     } else {
-      setSearchTerm('');
+      setSearchTerm(''); // user is typing in the 'other' field
       setOtherValue(value);
       setPortEntered({ name: value, unlocode: null });
     }

--- a/src/components/PortField.jsx
+++ b/src/components/PortField.jsx
@@ -64,10 +64,6 @@ const PortField = ({
     togglePortField(true);
   };
 
-  const clearInput = (e) => {
-    e.target.value = '';
-  };
-
   useEffect(() => {
     onConfirm(portEntered);
   }, [portEntered]);
@@ -75,8 +71,6 @@ const PortField = ({
   useEffect(() => {
     setSearchTerm(defaultValue);
   }, [defaultValue]);
-
-  console.log(portList);
 
   return (
     <>
@@ -93,7 +87,6 @@ const PortField = ({
           data-testid="port"
           onChange={handleSearchTermChange}
           value={searchTerm}
-          onFocus={(e) => clearInput(e)}
         />
         {portList.length > 0 && (
           <ComboboxPopover className="shadow-popup">

--- a/src/components/PortField.jsx
+++ b/src/components/PortField.jsx
@@ -15,9 +15,7 @@ import Auth from '../lib/Auth';
 let ports = [];
 
 function fetchPorts(query) {
-  if (query.length < 3) {
-    ports = [];
-  } else {
+  if (query.length >= 2) {
     axios.get(`${PORTS_URL}?name=${encodeURIComponent(query)}`, {
       headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
     })
@@ -41,6 +39,7 @@ const PortField = ({
 
   const handleSearchTermChange = (event) => {
     setSearchTerm(event.target.value);
+    fetchPorts(event.target.value);
   };
 
   const togglePortField = (other, value) => {
@@ -86,7 +85,6 @@ const PortField = ({
           onChange={handleSearchTermChange}
           value={searchTerm}
         />
-        {fetchPorts(searchTerm)}
         {ports && (
           <ComboboxPopover className="shadow-popup">
             {ports.length > 0 ? (
@@ -97,9 +95,9 @@ const PortField = ({
                 })}
               </ComboboxList>
             ) : (
-              <span style={{ display: 'none' }}>
+              <ComboboxList className="comboBoxListItem">
                 No results found
-              </span>
+              </ComboboxList>
             )}
           </ComboboxPopover>
         )}

--- a/src/components/Voyage/FormArrival.jsx
+++ b/src/components/Voyage/FormArrival.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { FORM_STEPS } from '../../constants/ClientConstants';
+import formatPortValue from '../../utils/formatPortData';
 import FormError from './FormError';
 import PortField from '../PortField';
 
@@ -11,18 +12,10 @@ const FormArrival = ({
   const [portValue, setPortValue] = useState();
   document.title = 'Intended arrival details';
 
-  const formatPortValue = () => {
-    if (!data.arrivalPort && !data.arrivalPortName) {
-      setPortValue();
-    } else if (!data.arrivalPort) {
-      setPortValue(data.arrivalPortName);
-    } else {
-      setPortValue(`${data.arrivalPortName} (${data.arrivalPort})`);
-    }
-  };
-
   useEffect(() => {
-    formatPortValue();
+    if (data.departurePort || data.departurePortName) {
+      setPortValue(formatPortValue(data, 'arrival'));
+    }
   }, [data]);
 
   if (!data) { return null; }

--- a/src/components/Voyage/FormArrival.jsx
+++ b/src/components/Voyage/FormArrival.jsx
@@ -163,7 +163,7 @@ const FormArrival = ({
             defaultValue={portValue}
             fieldName="arrivalPort"
             onConfirm={(result) => {
-              updatePortFields('arrivalPort', { name: result.name, unlocode: result.unlocode });
+              updatePortFields('arrivalPort', { name: result?.name || '', unlocode: result?.unlocode || '' });
             }}
           />
         </div>

--- a/src/components/Voyage/FormArrival.jsx
+++ b/src/components/Voyage/FormArrival.jsx
@@ -155,7 +155,7 @@ const FormArrival = ({
             defaultValue={data.arrivalPort}
             fieldName="arrivalPort"
             onConfirm={(result) => {
-              updatePortFields(false, { name: result.name, unlocode: result.unlocode });
+              updatePortFields('arrivalPort', { name: result.name, unlocode: result.unlocode });
             }}
           />
         </div>

--- a/src/components/Voyage/FormArrival.jsx
+++ b/src/components/Voyage/FormArrival.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { FORM_STEPS } from '../../constants/ClientConstants';
@@ -8,7 +8,22 @@ import PortField from '../PortField';
 const FormArrival = ({
   handleSubmit, handleChange, updatePortFields, data, errors, voyageId,
 }) => {
+  const [portValue, setPortValue] = useState();
   document.title = 'Intended arrival details';
+
+  const formatPortValue = () => {
+    if (!data.arrivalPort && !data.arrivalPortName) {
+      setPortValue();
+    } else if (!data.arrivalPort) {
+      setPortValue(data.arrivalPortName);
+    } else {
+      setPortValue(`${data.arrivalPortName} (${data.arrivalPort})`);
+    }
+  };
+
+  useEffect(() => {
+    formatPortValue();
+  }, [data]);
 
   if (!data) { return null; }
   return (
@@ -145,14 +160,14 @@ const FormArrival = ({
       <div id="arrivalLocation" className={`govuk-form-group ${errors.arrivalLocation ? 'govuk-form-group--error' : ''}`}>
         <FormError error={errors.arrivalLocation} />
         <div className={`govuk-form-group ${errors.arrivalPort ? 'govuk-form-group--error' : ''}`}>
-          <label className="govuk-label govuk-label--m" htmlFor="departurePort">
+          <label className="govuk-label govuk-label--m" htmlFor="arrivalPort">
             Name of arrival port or location
           </label>
           <div className="govuk-hint">
             For example MDL Hamble Point Marina
           </div>
           <PortField
-            defaultValue={data.arrivalPort}
+            defaultValue={portValue}
             fieldName="arrivalPort"
             onConfirm={(result) => {
               updatePortFields('arrivalPort', { name: result.name, unlocode: result.unlocode });

--- a/src/components/Voyage/FormCheck.jsx
+++ b/src/components/Voyage/FormCheck.jsx
@@ -8,6 +8,7 @@ import {
   SAVE_VOYAGE_VESSEL_URL,
 } from '../../constants/ClientConstants';
 import { formatUIDate } from '../../utils/date';
+import formatPortValue from '../../utils/formatPortData';
 import PeopleSummary from './PeopleSummary';
 
 const FormCheck = ({
@@ -46,7 +47,7 @@ const FormCheck = ({
         </div>
         <div className="govuk-summary-list__row">
           <dt className="govuk-summary-list__key">Departure point</dt>
-          <dd className="govuk-summary-list__value">{voyageData.departurePort}</dd>
+          <dd className="govuk-summary-list__value">{formatPortValue(voyageData, 'departure')}</dd>
         </div>
       </dl>
       <div className="govuk-summary-list govuk-!-margin-bottom-9">
@@ -84,7 +85,7 @@ const FormCheck = ({
         </div>
         <div className="govuk-summary-list__row">
           <dt className="govuk-summary-list__key">Arrival point</dt>
-          <dd className="govuk-summary-list__value">{voyageData.arrivalPort}</dd>
+          <dd className="govuk-summary-list__value">{formatPortValue(voyageData, 'arrival')}</dd>
         </div>
       </dl>
       <div className="govuk-summary-list govuk-!-margin-bottom-9">

--- a/src/components/Voyage/FormDeparture.jsx
+++ b/src/components/Voyage/FormDeparture.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { FORM_STEPS } from '../../constants/ClientConstants';
+import formatPortValue from '../../utils/formatPortData';
 import FormError from './FormError';
 import PortField from '../PortField';
 
@@ -11,18 +12,10 @@ const FormDeparture = ({
   const [portValue, setPortValue] = useState();
   document.title = 'Intended departure details';
 
-  const formatPortValue = () => {
-    if (!data.departurePort && !data.departurePortName) {
-      setPortValue();
-    } else if (!data.departurePort) {
-      setPortValue(data.departurePortName);
-    } else {
-      setPortValue(`${data.departurePortName} (${data.departurePort})`);
-    }
-  };
-
   useEffect(() => {
-    formatPortValue();
+    if (data.departurePort || data.departurePortName) {
+      setPortValue(formatPortValue(data, 'departure'));
+    }
   }, [data]);
 
   if (!data) { return null; }

--- a/src/components/Voyage/FormDeparture.jsx
+++ b/src/components/Voyage/FormDeparture.jsx
@@ -164,7 +164,7 @@ const FormDeparture = ({
             defaultValue={portValue}
             fieldName="departurePort"
             onConfirm={(result) => {
-              updatePortFields('departurePort', { name: result.name, unlocode: result.unlocode });
+              updatePortFields('departurePort', { name: result?.name || '', unlocode: result?.unlocode || '' });
             }}
           />
         </div>

--- a/src/components/Voyage/FormDeparture.jsx
+++ b/src/components/Voyage/FormDeparture.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { FORM_STEPS } from '../../constants/ClientConstants';
@@ -8,7 +8,26 @@ import PortField from '../PortField';
 const FormDeparture = ({
   handleSubmit, handleChange, updatePortFields, data, errors, voyageId,
 }) => {
+  const [fieldType, setFieldType] = useState();
+  const [portValue, setPortValue] = useState();
   document.title = 'Intended departure details';
+
+  const formatPortValue = () => {
+    if (!data.departurePort && !data.departurePortName) {
+      setPortValue();
+      setFieldType();
+    } else if (!data.departurePort) {
+      setPortValue(data.departurePortName);
+      setFieldType('not-combo');
+    } else {
+      setPortValue(`${data.departurePortName} (${data.departurePort})`);
+      setFieldType('combo');
+    }
+  };
+
+  useEffect(() => {
+    formatPortValue();
+  }, [data]);
 
   if (!data) { return null; }
   return (
@@ -153,10 +172,11 @@ const FormDeparture = ({
             For example MDL Hamble Point Marina
           </div>
           <PortField
-            defaultValue={data.departurePort}
+            defaultValue={portValue}
             fieldName="departurePort"
+            fieldType={fieldType}
             onConfirm={(result) => {
-              updatePortFields(true, { name: result.name, unlocode: result.unlocode });
+              updatePortFields('departurePort', { name: result.name, unlocode: result.unlocode });
             }}
           />
         </div>

--- a/src/components/Voyage/FormDeparture.jsx
+++ b/src/components/Voyage/FormDeparture.jsx
@@ -8,20 +8,16 @@ import PortField from '../PortField';
 const FormDeparture = ({
   handleSubmit, handleChange, updatePortFields, data, errors, voyageId,
 }) => {
-  const [fieldType, setFieldType] = useState();
   const [portValue, setPortValue] = useState();
   document.title = 'Intended departure details';
 
   const formatPortValue = () => {
     if (!data.departurePort && !data.departurePortName) {
       setPortValue();
-      setFieldType();
     } else if (!data.departurePort) {
       setPortValue(data.departurePortName);
-      setFieldType('not-combo');
     } else {
       setPortValue(`${data.departurePortName} (${data.departurePort})`);
-      setFieldType('combo');
     }
   };
 
@@ -174,7 +170,6 @@ const FormDeparture = ({
           <PortField
             defaultValue={portValue}
             fieldName="departurePort"
-            fieldType={fieldType}
             onConfirm={(result) => {
               updatePortFields('departurePort', { name: result.name, unlocode: result.unlocode });
             }}

--- a/src/components/Voyage/VoyageFormContainer.jsx
+++ b/src/components/Voyage/VoyageFormContainer.jsx
@@ -213,7 +213,7 @@ const FormVoyageContainer = () => {
       const data = formData;
 
       const fieldType = !document.getElementById('autocomplete')?.value ? (document.getElementById('autocomplete').name).replace('autocomplete', '') : null;
-      const updatedPortValues = fieldType ? { [fieldType]: null, [`${fieldType}Name`]: null } : null
+      const updatedPortValues = fieldType ? { [fieldType]: null, [`${fieldType}Name`]: null } : null;
 
       // update data for submitting
       const updatedData = { ...data, ...updatedPortValues };

--- a/src/components/Voyage/VoyageFormContainer.jsx
+++ b/src/components/Voyage/VoyageFormContainer.jsx
@@ -70,14 +70,9 @@ const FormVoyageContainer = () => {
     removeError(name);
   };
 
-  const updatePortFields = (isDeparture, portDetails) => {
-    if (isDeparture) {
-      setFormData({ ...formData, departurePort: portDetails.unlocode, departurePortName: portDetails.name });
-      removeError('departureLocation');
-    } else {
-      setFormData({ ...formData, arrivalPort: portDetails.unlocode, arrivalPortName: portDetails.name });
-      removeError('arrivalLocation');
-    }
+  const updatePortFields = (portField, portDetails) => {
+    setFormData({ ...formData, [portField]: portDetails.unlocode, [`${portField}Name`]: portDetails.name });
+    removeError(`${portField}location`);
   };
 
   const handleChange = (e) => {

--- a/src/components/Voyage/VoyageFormContainer.jsx
+++ b/src/components/Voyage/VoyageFormContainer.jsx
@@ -212,13 +212,11 @@ const FormVoyageContainer = () => {
       // get initial data set from formData
       const data = formData;
 
-      // check for autocomplete field current value
-      const autocompleteField = document.getElementById('autocomplete')?.name ? document.getElementById('autocomplete').name : null;
-      const autocompleteValue = document.getElementById('autocomplete')?.value === '' ? null : document.getElementById('autocomplete')?.value;
-      const autocompleteNameValue = autocompleteField ? { [autocompleteField]: autocompleteValue } : null;
+      const fieldType = !document.getElementById('autocomplete')?.value ? (document.getElementById('autocomplete').name).replace('autocomplete', '') : null;
+      const updatedPortValues = fieldType ? { [fieldType]: null, [`${fieldType}Name`]: null } : null
 
       // update data for submitting
-      const updatedData = { ...data, ...autocompleteNameValue };
+      const updatedData = { ...data, ...updatedPortValues };
       const dataToSubmit = formatDataToSubmit(sourceForm, updatedData, extraParams);
       setFormData(updatedData);
 

--- a/src/components/Voyage/__tests__/FormArrival.test.jsx
+++ b/src/components/Voyage/__tests__/FormArrival.test.jsx
@@ -19,6 +19,5 @@ describe('FormArrival', () => {
     expect(screen.getAllByRole('textbox').length).toBe(6); // day, month, year, hour, minute
     expect(screen.getAllByRole('combobox').length).toBe(1); // port
     expect(screen.getByTestId('portContainer')).toHaveAttribute('id', 'portsCombobox');
-    expect(screen.getByTestId('portContainer')).toHaveAttribute('name', 'arrivalPort');
   });
 });

--- a/src/components/Voyage/__tests__/FormDeparture.test.jsx
+++ b/src/components/Voyage/__tests__/FormDeparture.test.jsx
@@ -19,6 +19,5 @@ describe('FormDeparture', () => {
     expect(screen.getAllByRole('textbox').length).toBe(6); // day, month, year, hour, minute
     expect(screen.getAllByRole('combobox').length).toBe(1); // port
     expect(screen.getByTestId('portContainer')).toHaveAttribute('id', 'portsCombobox');
-    expect(screen.getByTestId('portContainer')).toHaveAttribute('name', 'departurePort');
   });
 });

--- a/src/utils/formatPortData.js
+++ b/src/utils/formatPortData.js
@@ -1,0 +1,10 @@
+const formatPortValue = (data, type) => {
+  if (!data[`${type}Port`]) {
+    return data[`${type}PortName`];
+  }
+  if (data[`${type}Port`] && data[`${type}PortName`]) {
+    return `${data[`${type}PortName`]} (${data[`${type}Port`]})`;
+  }
+};
+
+export default formatPortValue;


### PR DESCRIPTION
## Description

- Branches from https://github.com/UKHomeOffice/sgmr-service/pull/399 as extends on that functionality
- extending test coverage in SPCR-304

This PR
- extends on the autocomplete functionality to
- - throw error when user changing fields from valid value to null value
- - clear select list from view when selection made
- adds the port name to display along with unlocode in departure and arrival port
- - inputs
- - check answers page
- - manage reports page

## To test

- you need SPCR-304 and run `npm ci` to ensure autocomplete package is available
- create a new voyage
- enter a port in the autocomplete field
- select a port from the list
- go to next page
- go back
- > port should show name and unlocode (if selected port has a code) or name (if selected port has no code)
- delete the port
- try to go to next page
- > page should error due to port being required field
- go to manage reports 
- > arrival and departure ports should show name and unlocode 
- go to check answers page
- > arrival and departure ports should show name and unlocode 


## Developer Checklist

\* Required

- [ ] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
