### PR TITLE
SPCR-320 Change aria label for PortField combobox

### DIFF
--- a/src/components/PortField.jsx
+++ b/src/components/PortField.jsx
@@ -78,7 +78,7 @@ const PortField = ({
       <Combobox
         id="portsCombobox"
         data-testid="portContainer"
-        aria-label="Ports"
+        aria-label="Begin typing for port selections to appear"
         onSelect={(e) => handlePortSelection(e)}
       >
         <ComboboxInput


### PR DESCRIPTION
## Description
**This ticket also solves SPCR-321, as they both require the same solution**

> While a user is creating a new voyage, the screen reader reads the arrival point field as a combo box and to change the selection the user should use the arrow keys. However, using the arrow keys does not select an arrival point, the user has to begin to type in an arrival point and select the point from the dropdown list.
> 
> The user is able to use the arrow keys to navigate through the dropdown list but must begin typing an arrival point first for this to happen. Therefore the visually impaired user may become confused as to how to select an arrival point.

This ticket solves the above issue by changing the aria label to instruct the user that they must type in order for port selections to appear.

## To Test
- Sign in and create a new voyage plan
- Go to the departure page
- Use a screen reader to navigate to the port field
- You should be instructed by the voice assistant that you must type in order for port selections to appear
- Go to the arrival page
- You should have the same results as on the departure page

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
