### PR TITLE
SPCR-349 Fix departure and arrival error messages

### DIFF
--- a/src/components/Voyage/VoyageFormValidation.js
+++ b/src/components/Voyage/VoyageFormValidation.js
@@ -97,7 +97,7 @@ const VoyageFormValidation = async (dataToValidate, source) => {
     if (isDateToday(dataToValidate.departureDateYear, dataToValidate.departureDateMonth, dataToValidate.departureDateDay)) {
       errors.departureTime = 'You must enter a departure time in the future';
     } else {
-      errors.departureDate = 'You must enter a departure time in the future';
+      errors.departureDate = 'You must enter a departure date in the future';
     }
   }
   // Arrival date must be in the future
@@ -111,7 +111,7 @@ const VoyageFormValidation = async (dataToValidate, source) => {
     if (isDateToday(dataToValidate.arrivalDateYear, dataToValidate.arrivalDateMonth, dataToValidate.arrivalDateDay)) {
       errors.arrivalTime = 'You must enter an arrival time in the future';
     } else {
-      errors.arrivalDate = 'You must enter an arrival time in the future';
+      errors.arrivalDate = 'You must enter an arrival date in the future';
     }
   }
   // Arrival date must be after the departure date
@@ -131,7 +131,7 @@ const VoyageFormValidation = async (dataToValidate, source) => {
       dataToValidate.departureTimeMinute,
     ))
   ) {
-    errors.arrivalDate = 'You must enter an arrival time after your departure';
+    errors.arrivalDate = 'You must enter an arrival date after your departure';
   }
 
   if (errors) { scrollToTopOnError('voyageForm'); }

--- a/src/components/Voyage/__tests__/VoyageFormValidation.test.js
+++ b/src/components/Voyage/__tests__/VoyageFormValidation.test.js
@@ -123,7 +123,7 @@ describe('Voyage form invalid inputs', () => {
 
   it('should throw error if arrival date is in the past', async () => {
     const expectedErrors = {
-      arrivalDate: 'You must enter an arrival time in the future',
+      arrivalDate: 'You must enter an arrival date in the future',
     };
     const data = {
       arrivalDateDay: '01',
@@ -141,7 +141,7 @@ describe('Voyage form invalid inputs', () => {
 
   it('should throw error if departure date is in the past', async () => {
     const expectedErrors = {
-      departureDate: 'You must enter a departure time in the future',
+      departureDate: 'You must enter a departure date in the future',
     };
     const data = {
       departureDateDay: '01',
@@ -159,7 +159,7 @@ describe('Voyage form invalid inputs', () => {
 
   it('should throw error if arrival date is before departure', async () => {
     const expectedErrors = {
-      arrivalDate: 'You must enter an arrival time after your departure',
+      arrivalDate: 'You must enter an arrival date after your departure',
     };
     const data = {
       // arrival date is a day before departure


### PR DESCRIPTION
## Description
Currently when a user inputs a departure date in the past, the error reads 'You must enter a departure **time** in the future'. For consistency, this should actually read 'You must enter a departure **date** in the future'. 

Similarly, on the arrival page when a user enters an arrival date in the past the error reads 'You must enter an arrival **time** after your departure' but should read 'You must enter an arrival **date** after your departure'

## To test
- Click on a draft voyage plan
- Click to change departure details
- Delete the date and click 'Save and continue'
- The date input error should read 'date' not 'time'
- Enter todays date
- Put a time in the past and click 'Save and continue'
- The error on the time input should still read 'time'
- Repeat with the arrival details

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [X] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
