### PR TITLE
SPCR-325 Add correct labelling for edit texts in FormResponsiblePerson

### DIFF
--- a/src/components/Voyage/FormResponsiblePerson.jsx
+++ b/src/components/Voyage/FormResponsiblePerson.jsx
@@ -15,12 +15,13 @@ const FormResponsiblePerson = ({
       </p>
 
       <div id="responsibleGivenName" className={`govuk-form-group ${errors.responsibleGivenName ? 'govuk-form-group--error' : ''}`}>
-        <label className="govuk-label govuk-label--m" htmlFor="responsibleGivenName">
+        <label className="govuk-label govuk-label--m" htmlFor="responsibleGivenName-input">
           First name
         </label>
         <FormError error={errors.responsibleGivenName} />
         <input
           className="govuk-input"
+          id="responsibleGivenName-input"
           name="responsibleGivenName"
           type="text"
           value={data.responsibleGivenName || ''}
@@ -29,12 +30,13 @@ const FormResponsiblePerson = ({
       </div>
 
       <div id="responsibleSurname" className={`govuk-form-group ${errors.responsibleSurname ? 'govuk-form-group--error' : ''}`}>
-        <label className="govuk-label govuk-label--m" htmlFor="responsibleSurname">
+        <label className="govuk-label govuk-label--m" htmlFor="responsibleSurname-input">
           Last name
         </label>
         <FormError error={errors.responsibleSurname} />
         <input
           className="govuk-input"
+          id="responsibleSurname-input"
           name="responsibleSurname"
           type="text"
           value={data.responsibleSurname || ''}
@@ -42,7 +44,7 @@ const FormResponsiblePerson = ({
         />
       </div>
       <div id="responsibleContactNo" className={`govuk-form-group ${errors.responsibleContactNo ? 'govuk-form-group--error' : ''}`}>
-        <label className="govuk-label govuk-label--m" htmlFor="responsibleContactNo">
+        <label className="govuk-label govuk-label--m" htmlFor="responsibleContactNo-input">
           Contact telephone number
         </label>
         <FormError error={errors.responsibleContactNo} />
@@ -51,6 +53,7 @@ const FormResponsiblePerson = ({
         </div>
         <input
           className="govuk-input"
+          id="responsibleContactNo-input"
           name="responsibleContactNo"
           type="text"
           value={data.responsibleContactNo || ''}
@@ -61,13 +64,14 @@ const FormResponsiblePerson = ({
       <fieldset className="govuk-fieldset">
         <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">Address</legend>
         <div id="responsibleAddressLine1" className={`govuk-form-group ${errors.responsibleAddressLine1 ? 'govuk-form-group--error' : ''}`}>
-          <label className="govuk-label" htmlFor="responsibleAddressLine1">
+          <label className="govuk-label" htmlFor="responsibleAddressLine1-input">
             House number / building and street
             <span className="govuk-visually-hidden">line 1 of 2</span>
           </label>
           <FormError error={errors.responsibleAddressLine1} />
           <input
             className="govuk-input"
+            id="responsibleAddressLine1-input"
             name="responsibleAddressLine1"
             type="text"
             value={data.responsibleAddressLine1 || ''}
@@ -75,12 +79,13 @@ const FormResponsiblePerson = ({
           />
         </div>
         <div id="responsibleAddressLine2" className="govuk-form-group">
-          <label className="govuk-label" htmlFor="responsibleAddressLine2">
+          <label className="govuk-label" htmlFor="responsibleAddressLine2-input">
             <span className="govuk-visually-hidden">Building and street line 2 of 2</span>
           </label>
           <FormError error={errors.responsibleAddressLine2} />
           <input
             className="govuk-input"
+            id="responsibleAddressLine2-input"
             name="responsibleAddressLine2"
             type="text"
             value={data.responsibleAddressLine2 || ''}
@@ -88,10 +93,11 @@ const FormResponsiblePerson = ({
           />
         </div>
         <div id="responsibleTown" className={`govuk-form-group ${errors.responsibleTown ? 'govuk-form-group--error' : ''}`}>
-          <label className="govuk-label" htmlFor="responsibleTown">Town or city</label>
+          <label className="govuk-label" htmlFor="responsibleTown-input">Town or city</label>
           <FormError error={errors.responsibleTown} />
           <input
             className="govuk-input govuk-!-width-two-thirds"
+            id="responsibleTown-input"
             name="responsibleTown"
             type="text"
             value={data.responsibleTown || ''}
@@ -103,10 +109,11 @@ const FormResponsiblePerson = ({
              backend needs to be updated first */
         }
         <div id="responsibleCounty" className={`govuk-form-group ${errors.responsibleCounty ? 'govuk-form-group--error' : ''}`}>
-          <label className="govuk-label" htmlFor="responsibleCounty">Country</label>
+          <label className="govuk-label" htmlFor="responsibleCounty-input">Country</label>
           <FormError error={errors.responsibleCounty} />
           <input
             className="govuk-input govuk-!-width-two-thirds"
+            id="responsibleCounty-input"
             name="responsibleCounty"
             type="text"
             value={data.responsibleCounty || ''}
@@ -117,6 +124,7 @@ const FormResponsiblePerson = ({
           <label className="govuk-label" htmlFor="responsiblePostcode">Postcode or ZIP</label>
           <input
             className="govuk-input govuk-input--width-10"
+            id="responsiblePostcode-input"
             name="responsiblePostcode"
             type="text"
             value={data.responsiblePostcode || ''}


### PR DESCRIPTION
## Description
> While the user is inputting the skipper's details to the new voyage plan, the JAWS screen reader does not read out the Contact telephone number label for the field. Therefore, the user may be unsure as to what details are required for this field.

Turns out that all of the text input fields weren't labelled properly, so all of them have been fixed for the skipper details page.

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
