### PR TITLE
SPCR-359 Change delete account link to button

### DIFF
--- a/src/components/User/EditAccount.jsx
+++ b/src/components/User/EditAccount.jsx
@@ -106,6 +106,11 @@ const EditAccount = () => {
     }
   };
 
+  // Handle Delete
+  const handleDelete = () => {
+    history.push('/account/delete');
+  };
+
   return (
     <div className="govuk-width-container ">
       <div className="govuk-breadcrumbs">
@@ -215,9 +220,9 @@ const EditAccount = () => {
         <h2 className="govuk-heading-m">Delete account</h2>
         <p className="govuk-body-m">Delete this account and stop using the service.</p>
         <p className="govuk-body">
-          <Link className="govuk-button govuk-button--warning" to="/account/delete">
+          <button className="govuk-button govuk-button--warning" type="button" onClick={handleDelete}>
             Delete this account
-          </Link>
+          </button>
         </p>
       </main>
     </div>

--- a/src/components/User/__tests__/EditAccount.test.jsx
+++ b/src/components/User/__tests__/EditAccount.test.jsx
@@ -42,7 +42,8 @@ describe('Edit Account page details', () => {
     expect(screen.getByDisplayValue('John')).toBeInTheDocument();
     expect(screen.getByDisplayValue('Doe')).toBeInTheDocument();
     expect(screen.getByDisplayValue('07444112888')).toBeInTheDocument();
-    expect(screen.getByRole('button')).toHaveTextContent('Save changes');
+    expect(screen.getAllByRole('button')[0]).toHaveTextContent('Save changes');
+    expect(screen.getAllByRole('button')[1]).toHaveTextContent('Delete this account');
   });
 });
 


### PR DESCRIPTION
## Description
> When using the JAWS screen reader and is editing their account information, the screen reader reads that the 'Delete this account button' is a link, not a button.
> 
> The Save button is read out correctly.

The 'Delete this account' button was coded as a link, this has now been changed to a button which has fixed the screen reader issue

## To Test
- Sign in and go to edit account page
- Use a screenreader and go to the 'delete this account' button
- You should hear the button be described as a button and not a link  

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [X] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
