### PR TITLE
1.2.0 SPCR-342 Add hint ids and remove unnecessary aria attributes

### DIFF
--- a/src/components/People/FormPerson.jsx
+++ b/src/components/People/FormPerson.jsx
@@ -95,14 +95,14 @@ const FormPerson = ({
       </div>
 
       <div id="dateOfBirth" className={`govuk-form-group ${errors.dateOfBirth ? 'govuk-form-group--error' : ''}`}>
-        <fieldset className="govuk-fieldset" role="group" aria-describedby="dob-hint">
+        <fieldset className="govuk-fieldset" role="group" aria-describedby="dateOfBirth-hint">
           <legend className="govuk-fieldset__legend">
             <label className="govuk-label" htmlFor="dateOfBirth">
               Date of Birth
             </label>
             <FormError error={errors.dateOfBirth} />
           </legend>
-          <div className="govuk-hint">
+          <div className="govuk-hint" id="dateOfBirth-hint">
             For example, 31 3 1980
           </div>
           <div className="govuk-date-input">
@@ -350,7 +350,7 @@ const FormPerson = ({
           Issuing state
         </label>
         <FormError error={errors.documentIssuingState} />
-        <div className="govuk-hint">
+        <div className="govuk-hint" id="documentIssuingState-hint">
           Please enter 3 letter ISO country code, for example GBR
         </div>
         <input
@@ -360,6 +360,7 @@ const FormPerson = ({
           maxLength={3}
           value={formData.documentIssuingState || ''}
           onChange={handleChange}
+          aria-describedby="documentIssuingState-hint"
         />
       </div>
 
@@ -370,7 +371,7 @@ const FormPerson = ({
               Expiry date
             </label>
           </legend>
-          <div className="govuk-hint">
+          <div className="govuk-hint" id="documentExpiryDate-hint">
             For example, 31 3 2022
           </div>
           <div className="govuk-date-input">

--- a/src/components/People/FormPerson.jsx
+++ b/src/components/People/FormPerson.jsx
@@ -201,7 +201,7 @@ const FormPerson = ({
       </div>
 
       <div id="peopleType" className={`govuk-form-group ${errors.peopleType ? 'govuk-form-group--error' : ''}`}>
-        <fieldset className="govuk-fieldset" aria-describedby="person-type-hint">
+        <fieldset className="govuk-fieldset">
           <legend className="govuk-fieldset__legend">
             <label className="govuk-fieldset__heading" htmlFor="personType">
               Person type
@@ -257,7 +257,7 @@ const FormPerson = ({
 
       <h2 className="govuk-heading-l">Travel document details</h2>
       <div id="documentType" className={`govuk-form-group ${errors.documentType ? 'govuk-form-group--error' : ''}`}>
-        <fieldset className="govuk-fieldset" aria-describedby="travel-document-type-hint">
+        <fieldset className="govuk-fieldset">
           <legend className="govuk-fieldset__legend">
             <label className="govuk-fieldset__heading" htmlFor="travelDoc">
               Travel document type

--- a/src/components/Voyage/FormArrival.jsx
+++ b/src/components/Voyage/FormArrival.jsx
@@ -27,14 +27,14 @@ const FormArrival = ({
       </p>
 
       <div id="arrivalDate" className={`govuk-form-group ${errors.arrivalDate ? 'govuk-form-group--error' : ''}`}>
-        <fieldset className="govuk-fieldset" role="group" aria-describedby="dob-hint">
+        <fieldset className="govuk-fieldset" role="group" aria-describedby="arrivalDate-hint">
           <legend className="govuk-fieldset__legend">
             <label className="govuk-label govuk-label--m" htmlFor="arrivalDate">
               Intended arrival date
             </label>
             <FormError error={errors.arrivalDate} />
           </legend>
-          <div className="govuk-hint">
+          <div className="govuk-hint" id="arrivalDate-hint">
             For example, 20 2 2020
           </div>
           <div className="govuk-date-input">
@@ -106,7 +106,7 @@ const FormArrival = ({
             </label>
             <FormError error={errors.arrivalTime} />
           </legend>
-          <div className="govuk-hint">
+          <div className="govuk-hint" id="arrivalTime-hint">
             For example, 17 30
           </div>
           <div className="govuk-date-input">

--- a/src/components/Voyage/FormDeparture.jsx
+++ b/src/components/Voyage/FormDeparture.jsx
@@ -27,14 +27,14 @@ const FormDeparture = ({
       </p>
 
       <div id="departureDate" className={`govuk-form-group ${errors.departureDate ? 'govuk-form-group--error' : ''}`}>
-        <fieldset className="govuk-fieldset" role="group" aria-describedby="dob-hint">
+        <fieldset className="govuk-fieldset" role="group" aria-describedby="departureDate-hint">
           <legend className="govuk-fieldset__legend">
             <label className="govuk-label govuk-label--m" htmlFor="departureDate">
               Departure date
             </label>
             <FormError error={errors.departureDate} />
           </legend>
-          <div className="govuk-hint">
+          <div className="govuk-hint" id="departureDate-hint">
             For example, 20 2 2020
           </div>
           <div className="govuk-date-input">
@@ -106,7 +106,7 @@ const FormDeparture = ({
             </label>
             <FormError error={errors.departureTime} />
           </legend>
-          <div className="govuk-hint">
+          <div className="govuk-hint" id="departureTime-hint">
             For example, 17 30
           </div>
           <div className="govuk-date-input">

--- a/src/components/Voyage/FormVoyagePeopleManifest.jsx
+++ b/src/components/Voyage/FormVoyagePeopleManifest.jsx
@@ -83,7 +83,6 @@ const FormVoyagePeopleManifest = ({
       <div className="govuk-form-group">
         <fieldset
           className="govuk-fieldset"
-          aria-describedby="confirm-people-hint"
         >
           <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
             <h1 className="govuk-fieldset__heading govuk-!-font-weight-regular">


### PR DESCRIPTION
## Description
Aria-describedby is looking for a corresponding id but these are missing. Add hint ids to the divs containing hint text and remove unnecessary aria hints where hint text is not displayed.

## To test
- Go to person tab
- Click on save a person
- open AXE tools in devtools (needs chrome plugin)
- Run scan
- > There should be no errors mentioning that ARIA attributes must conform to valid values - (there may be other errors that will be resolved in other tickets)
- Repeat with voyage plan departure form (page 1), arrival form (page 2) and people manifest (page 5)

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
