### PR TITLE
1.2.0 SPCR-335 - Add id attribute to inputs

### DIFF
--- a/src/components/People/FormPerson.jsx
+++ b/src/components/People/FormPerson.jsx
@@ -12,11 +12,12 @@ const FormPerson = ({
   return (
     <section>
       <div id="firstName" className={`govuk-form-group ${errors.firstName ? 'govuk-form-group--error' : ''}`}>
-        <label className="govuk-label" htmlFor="firstName">
+        <label className="govuk-label" htmlFor="firstName-input">
           First name
           <FormError error={errors.firstName} />
           <input
             className="govuk-input"
+            id="firstName-input"
             name="firstName"
             type="text"
             value={formData.firstName || ''}
@@ -26,11 +27,12 @@ const FormPerson = ({
       </div>
 
       <div id="lastName" className={`govuk-form-group ${errors.lastName ? 'govuk-form-group--error' : ''}`}>
-        <label className="govuk-label" htmlFor="lastName">
+        <label className="govuk-label" htmlFor="lastName-input">
           Last Name
           <FormError error={errors.lastName} />
           <input
             className="govuk-input"
+            id="lastName-input"
             name="lastName"
             type="text"
             value={formData.lastName || ''}
@@ -168,11 +170,12 @@ const FormPerson = ({
       </div>
 
       <div id="placeOfBirth" className={`govuk-form-group ${errors.placeOfBirth ? 'govuk-form-group--error' : ''}`}>
-        <label className="govuk-label" htmlFor="placeOfBirth">
+        <label className="govuk-label" htmlFor="placeOfBirth-input">
           Place of birth
           <FormError error={errors.placeOfBirth} />
           <input
             className="govuk-input"
+            id="placeOfBirth-input"
             name="placeOfBirth"
             type="text"
             value={formData.placeOfBirth || ''}
@@ -182,12 +185,13 @@ const FormPerson = ({
       </div>
 
       <div id="nationality" className={`govuk-form-group ${errors.nationality ? 'govuk-form-group--error' : ''}`}>
-        <label className="govuk-label" htmlFor="nationality">
+        <label className="govuk-label" htmlFor="nationality-select">
           Nationality
         </label>
         <FormError error={errors.nationality} />
         <select
           className="govuk-select"
+          id="nationality-select"
           name="nationality"
           type="text"
           value={formData.nationality || 'Please select'}
@@ -332,11 +336,12 @@ const FormPerson = ({
       </div>
 
       <div id="documentNumber" className={`govuk-form-group ${errors.documentNumber ? 'govuk-form-group--error' : ''}`}>
-        <label className="govuk-label" htmlFor="documentNumber">
+        <label className="govuk-label" htmlFor="documentNumber-input">
           Document number
           <FormError error={errors.documentNumber} />
           <input
             className="govuk-input"
+            id="documentNumber-input"
             name="documentNumber"
             type="text"
             value={formData.documentNumber || ''}
@@ -346,7 +351,7 @@ const FormPerson = ({
       </div>
 
       <div id="documentIssuingState" className={`govuk-form-group ${errors.documentIssuingState ? 'govuk-form-group--error' : ''}`}>
-        <label className="govuk-label" htmlFor="documentIssuingState">
+        <label className="govuk-label" htmlFor="documentIssuingState-input">
           Issuing state
         </label>
         <FormError error={errors.documentIssuingState} />
@@ -355,6 +360,7 @@ const FormPerson = ({
         </div>
         <input
           className="govuk-input govuk-input--width-3"
+          id="documentIssuingState-input"
           name="documentIssuingState"
           type="text"
           maxLength={3}

--- a/src/components/PortField.jsx
+++ b/src/components/PortField.jsx
@@ -120,7 +120,7 @@ const PortField = ({
             Please enter the location if it&apos;s not available in the dropdown
           </div>
           <input
-            id="portOtherInput"
+            id={`${fieldName}other`}
             className="govuk-input"
             name={`${fieldName}other`}
             type="text"

--- a/src/components/Vessel/FormVessel.jsx
+++ b/src/components/Vessel/FormVessel.jsx
@@ -9,13 +9,14 @@ const FormVessel = ({
   return (
     <section>
       <div id="vesselName" className={`govuk-form-group ${errors.vesselName ? 'govuk-form-group--error' : ''}`}>
-        <label className="govuk-label" htmlFor="vesselName">
+        <label className="govuk-label" htmlFor="vesselName-input">
           Pleasure craft name
         </label>
         <FormError error={errors.vesselName} />
         <div className="govuk-hint">For example Baroness</div>
         <input
           className="govuk-input"
+          id="vesselName-input"
           name="vesselName"
           type="text"
           value={formData.vesselName || ''}
@@ -24,13 +25,14 @@ const FormVessel = ({
       </div>
 
       <div id="vesselType" className={`govuk-form-group ${errors.vesselType ? 'govuk-form-group--error' : ''}`}>
-        <label className="govuk-label" htmlFor="vesselType">
+        <label className="govuk-label" htmlFor="vesselType-input">
           Pleasure craft type
         </label>
         <FormError error={errors.vesselType} />
         <div className="govuk-hint">For example Yacht or Sailboat</div>
         <input
           className="govuk-input"
+          id="vesselType-input"
           name="vesselType"
           type="text"
           value={formData.vesselType || ''}
@@ -39,13 +41,14 @@ const FormVessel = ({
       </div>
 
       <div id="moorings" className={`govuk-form-group ${errors.moorings ? 'govuk-form-group--error' : ''}`}>
-        <label className="govuk-label" htmlFor="moorings">
+        <label className="govuk-label" htmlFor="moorings-input">
           Usual moorings
         </label>
         <div className="govuk-hint">A description, UNLOCODE or set of Coordinates for where the pleasure craft is usually moored</div>
         <FormError error={errors.moorings} />
         <input
           className="govuk-input"
+          id="moorings-input"
           name="moorings"
           type="text"
           value={formData.moorings || ''}
@@ -54,12 +57,13 @@ const FormVessel = ({
       </div>
 
       <div id="registration" className={`govuk-form-group ${errors.registration ? 'govuk-form-group--error' : ''}`}>
-        <label className="govuk-label" htmlFor="registration">
+        <label className="govuk-label" htmlFor="registration-input">
           Registration number
         </label>
         <FormError error={errors.registration} />
         <input
           className="govuk-input"
+          id="registration-input"
           name="registration"
           type="text"
           value={formData.registration || ''}
@@ -68,11 +72,12 @@ const FormVessel = ({
       </div>
 
       <div id="hullIdentificationNumber" className="govuk-form-group">
-        <label className="govuk-label" htmlFor="hullIdentificationNumber">
+        <label className="govuk-label" htmlFor="hullIdentificationNumber-input">
           Hull identification number (optional)
         </label>
         <input
           className="govuk-input"
+          id="hullIdentificationNumber-input"
           name="hullIdentificationNumber"
           type="text"
           value={formData.hullIdentificationNumber || ''}
@@ -81,11 +86,12 @@ const FormVessel = ({
       </div>
 
       <div id="callsign" className="govuk-form-group">
-        <label className="govuk-label" htmlFor="callsign">
+        <label className="govuk-label" htmlFor="callsign-input">
           Callsign (optional)
         </label>
         <input
           className="govuk-input"
+          id="callsign-input"
           name="callsign"
           type="text"
           value={formData.callsign || ''}
@@ -94,11 +100,12 @@ const FormVessel = ({
       </div>
 
       <div id="vesselNationality" className="govuk-form-group">
-        <label className="govuk-label" htmlFor="vesselNationality">
+        <label className="govuk-label" htmlFor="vesselNationality-select">
           Pleasure craft nationality (optional)
         </label>
         <select
           className="govuk-select"
+          id="vesselNationality-select"
           name="vesselNationality"
           value={formData.vesselNationality || ''}
           onChange={handleChange}
@@ -111,11 +118,12 @@ const FormVessel = ({
       </div>
 
       <div id="portOfRegistry" className="govuk-form-group">
-        <label className="govuk-label" htmlFor="portOfRegistry">
+        <label className="govuk-label" htmlFor="portOfRegistry-input">
           Port of registry (optional)
         </label>
         <input
           className="govuk-input"
+          id="portOfRegistry-input"
           name="portOfRegistry"
           type="text"
           value={formData.portOfRegistry || ''}

--- a/src/components/Voyage/FormResponsiblePerson.jsx
+++ b/src/components/Voyage/FormResponsiblePerson.jsx
@@ -121,7 +121,7 @@ const FormResponsiblePerson = ({
           />
         </div>
         <div id="responsiblePostcode" className="govuk-form-group">
-          <label className="govuk-label" htmlFor="responsiblePostcode">Postcode or ZIP</label>
+          <label className="govuk-label" htmlFor="responsiblePostcode-input">Postcode or ZIP</label>
           <input
             className="govuk-input govuk-input--width-10"
             id="responsiblePostcode-input"

--- a/src/components/Voyage/PeopleTable.jsx
+++ b/src/components/Voyage/PeopleTable.jsx
@@ -50,7 +50,7 @@ const PeopleTable = ({ peopleData, onSelectionChange = () => {} }) => {
                     checked={peopleToRemove.includes(person.id)}
                   />
                   <label className="govuk-label govuk-checkboxes__label" htmlFor={person.id}>
-                    <span className="govuk-visually-hidden" >{`Select ${person.firstName} ${person.lastName}`}</span>
+                    <span className="govuk-visually-hidden">{`Select ${person.firstName} ${person.lastName}`}</span>
                   </label>
                 </div>
               </td>

--- a/src/components/Voyage/PeopleTable.jsx
+++ b/src/components/Voyage/PeopleTable.jsx
@@ -43,12 +43,15 @@ const PeopleTable = ({ peopleData, onSelectionChange = () => {} }) => {
                     type="checkbox"
                     className="govuk-checkboxes__input"
                     value={person.id}
+                    id={person.id}
                     data-testid={person.id}
                     onChange={handleCheckboxes}
                     name="people"
                     checked={peopleToRemove.includes(person.id)}
                   />
-                  <label className="govuk-label govuk-checkboxes__label" htmlFor={person.id}>&nbsp;</label>
+                  <label className="govuk-label govuk-checkboxes__label" htmlFor={person.id}>
+                    <span className="govuk-visually-hidden" >{`Select ${person.firstName} ${person.lastName}`}</span>
+                  </label>
                 </div>
               </td>
               <td className="govuk-table__cell" role="cell">


### PR DESCRIPTION
## Description
Currently, there are no ids on the inputs which means that the labels are not linked. Id attributes need to be added to any inputs that do not have an id, so that the htmlFor labels link to the inputs. 

### To test 
- Go to person tab
- Click on save a person
- Open AXE tools in devtools (needs chrome plugin)
- Run scan
There should be no errors mentioning that form elements must have labels - (there may be other errors that will be resolved in other tickets)

Repeat with **save a pleasure craft form**, voyage plan **departure and arrival (pages 1 &2 )**, and **people manifest (pages 4 & 5)**

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
