### PR TITLE
SPCR-329 Fix console warning about @reach/combobox styles

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -1,6 +1,7 @@
 @import '~accessible-autocomplete/dist/accessible-autocomplete.min';
 @import '~govuk-frontend/govuk/all';
 @import './LoadingSpinner.scss';
+@import '@reach/combobox/styles.css';
 
 // header
 .govuk-header__logotype-crown {


### PR DESCRIPTION
## Description
Fixed a console warning regarding a stylesheet that was previously not included in the service.

## To Test
- Sign in
- Open the developer console
- Create a new voyage plan
- Go to the departure form
- You should not see an error relating to `@reach/combobox/styles.css` not being included
- Go the the arrival form
- You should not see an error relating to `@reach/combobox/styles.css` not being included

## Developer Checklist

\* Required

- [X] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [X] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*


Ensure you delete the branch once the Pull Request is merged.
