### PR TITLE
SPCR-355 Create country component

### DIFF
--- a/src/components/CountryField.jsx
+++ b/src/components/CountryField.jsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react';
+
+import axios from 'axios';
+
+import {
+  Combobox,
+  ComboboxInput,
+  ComboboxPopover,
+  ComboboxList,
+  ComboboxOption,
+} from '@reach/combobox';
+import { NATIONALITIES_URL } from '../constants/ApiConstants';
+import Auth from '../lib/Auth';
+
+const CountryField = ({
+  onConfirm = () => {}, fieldName, defaultValue,
+}) => {
+  const [countryList, setCountryList] = useState([]);
+  const [countryEntered, setCountryEntered] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const optionData = React.useRef({});
+
+  const fetchCountries = (query) => {
+    if (query.length >= 2) {
+      axios.get(`${NATIONALITIES_URL}?label=${encodeURIComponent(query)}`, {
+        headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
+      })
+        .then((resp) => {
+          setCountryList(resp.data);
+        })
+        .catch((err) => {
+          if (err.response) {
+            setCountryList([]);
+          }
+        });
+    }
+  };
+
+  const handleSearchTermChange = (event) => {
+    setSearchTerm(event.target.value);
+    fetchCountries(event.target.value);
+  };
+
+  const handleCountrySelection = (country) => {
+    setSearchTerm(country.label);
+    setCountryEntered(country.value);
+    setCountryList([]);
+  };
+
+  useEffect(() => {
+    onConfirm(countryEntered);
+  }, [countryEntered]);
+
+  useEffect(() => {
+    setSearchTerm(defaultValue || '');
+  }, [defaultValue]);
+
+  return (
+    <Combobox
+      id="countryCombobox"
+      data-testid="countryContainer"
+      aria-label="Begin typing for country selections to appear"
+      onSelect={(value) => {
+        // O(1) lookup for data
+        const data = optionData.current[value];
+        handleCountrySelection(data);
+      }}
+    >
+      <ComboboxInput
+        id="countryCombobox-input"
+        className="govuk-input"
+        data-testid="country-input"
+        name={`autocomplete${fieldName}`}
+        onChange={handleSearchTermChange}
+        value={searchTerm}
+      />
+      {countryList.length > 0 && (
+      <ComboboxPopover className="shadow-popup">
+        {countryList.length > 0 ? (
+          <ComboboxList className="comboBoxListItem">
+            {countryList.slice(0, 10).map((country) => {
+              optionData.current[country.label] = {
+                label: country.label,
+                value: country.value,
+              };
+              return (
+                <ComboboxOption
+                  role="option"
+                  key={country.value}
+                  value={country.label}
+                />
+              );
+            })}
+          </ComboboxList>
+        ) : (
+          <ComboboxList className="comboBoxListItem">
+            No results found
+          </ComboboxList>
+        )}
+      </ComboboxPopover>
+      )}
+    </Combobox>
+  );
+};
+
+export default CountryField;

--- a/src/components/CountryField.jsx
+++ b/src/components/CountryField.jsx
@@ -59,8 +59,8 @@ const CountryField = ({
   return (
     <Combobox
       id="countryCombobox"
-      data-testid="countryContainer"
       aria-label="Begin typing for country selections to appear"
+      autocomplete={false}
       onSelect={(value) => {
         // O(1) lookup for data
         const data = optionData.current[value];
@@ -70,7 +70,6 @@ const CountryField = ({
       <ComboboxInput
         id="countryCombobox-input"
         className="govuk-input"
-        data-testid="country-input"
         name={`autocomplete${fieldName}`}
         onChange={handleSearchTermChange}
         value={searchTerm}

--- a/src/components/CountryNationalityField.jsx
+++ b/src/components/CountryNationalityField.jsx
@@ -12,7 +12,7 @@ import {
 import { NATIONALITIES_URL } from '../constants/ApiConstants';
 import Auth from '../lib/Auth';
 
-const CountryField = ({
+const CountryNationalityField = ({
   onConfirm = () => {}, fieldName, defaultValue,
 }) => {
   const [countryList, setCountryList] = useState([]);
@@ -103,4 +103,4 @@ const CountryField = ({
   );
 };
 
-export default CountryField;
+export default CountryNationalityField;

--- a/src/constants/ApiConstants.js
+++ b/src/constants/ApiConstants.js
@@ -14,6 +14,7 @@ export const RESEND_VERIFICATION_CODE_URL = `${apiUrl}/resend-verification-code`
 export const REGISTRATION_URL = `${apiUrl}/registration`;
 export const PORTS_URL = `${apiUrl}/ports`;
 export const COUNTRIES_URL = `${apiUrl}/countries`;
+export const NATIONALITIES_URL = `${apiUrl}/nationalities`;
 export const ACTIVATE_ACCOUNT = `${apiUrl}/activate-account`;
 export const RESEND_ACTIVATION_LINK = `${apiUrl}/resend-activation-link`;
 


### PR DESCRIPTION
### AC / Description of changes
> Dev requirements
>- a reusable component
>- can search on 3+ letters 
>- returns search results that match country name
>- returns search results that match country ISO code
>- uses the /nationalities endpoint
>  
> AC
> Given I am interacting with a country/nationality field
> When I have typed at least 3 letters
> I am shown a list of countries names or ISO codes that contain those letters

Created a new country field component that meets these requirements.

### To Test
- Import CountryField into `DepartureForm.jsx` and create a country component somewhere in the file for testing purposes (discard these changes later)
- `npm start` and navigate to the departure form
- Type one or two letters into the country field
- You should get no results
- Type 3 or more letters
- Results should appear
- Select a result
- It should close the drop down and place the result into the field

### Notes
- Writing unit tests for this component may not be possible, as the autocomplete has a popover which cannot be detected by the jest tests
- There is a backend issue where countries cannot be searched by iso code on the endpoint, preventing it from being able to be implemented here
- The reference data for Nationality uses the country name in most cases rather than the demonym, so we have it as one data set to serve both
---
* remember to merge to feature branches not master *


