### PR TITLE
SPCR-303 Move error summary to its own component

### DIFF
--- a/src/components-v2/ErrorSummary.jsx
+++ b/src/components-v2/ErrorSummary.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
 
 const ErrorSummary = ({ errors }) => {
-
   const handleErrorClick = (e, id) => {
     e.preventDefault();
     const scrollToError = document.getElementById(id);
     scrollToError.scrollIntoView();
-    document.getElementById(`${id}Input`).focus()
+    document.getElementById(`${id}Input`).focus();
   };
 
   if (Object.keys(errors).length === 0) return null;
@@ -26,7 +25,7 @@ const ErrorSummary = ({ errors }) => {
         </ul>
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default ErrorSummary
+export default ErrorSummary;

--- a/src/components-v2/ErrorSummary.jsx
+++ b/src/components-v2/ErrorSummary.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+const ErrorSummary = ({ errors }) => {
+
+  const handleErrorClick = (e, id) => {
+    e.preventDefault();
+    const scrollToError = document.getElementById(id);
+    scrollToError.scrollIntoView();
+    document.getElementById(`${id}Input`).focus()
+  };
+
+  if (Object.keys(errors).length === 0) return null;
+  return (
+    <div className="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabIndex="-1" data-module="govuk-error-summary">
+      <h2 className="govuk-error-summary__title" id="error-summary-title">
+        There is a problem
+      </h2>
+      <div className="govuk-error-summary__body">
+        <ul className="govuk-list govuk-error-summary__list">
+          {Object.entries(errors).reverse().map((elem) => (
+            <li key={elem[0]}>
+              {elem[0] !== 'helpError' && <a onClick={(e) => handleErrorClick(e, elem[0])} href={elem[0]}>{elem[1]}</a>}
+              {elem[0] === 'helpError' && <a href="/page/help">{elem[1]}</a>}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+export default ErrorSummary

--- a/src/pages/people/PersonForm.jsx
+++ b/src/pages/people/PersonForm.jsx
@@ -56,12 +56,6 @@ const PersonForm = ({ source, type }) => {
     setErrors(removeError(e.target.name, errors));
   };
 
-  const handleErrorClick = (e, id) => {
-    e.preventDefault();
-    const scrollToError = document.getElementById(id);
-    scrollToError.scrollIntoView();
-  };
-
   const validateForm = async () => {
     const newErrors = await validate(PeopleValidation[`page${formPageIs}`], formData);
     setErrors(newErrors);
@@ -185,24 +179,6 @@ const PersonForm = ({ source, type }) => {
                 && (
                 <>
                   <h1 className="govuk-heading-l">{title}</h1>
-                  {Object.keys(errors).length >= 1 && (
-                  <div className="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabIndex="-1" data-module="govuk-error-summary">
-                    <h2 className="govuk-error-summary__title">
-                      There is a problem
-                    </h2>
-                    <div className="govuk-error-summary__body">
-                      <ul className="govuk-list govuk-error-summary__list">
-                        {Object.entries(errors).reverse().map((elem) => (
-                          <li key={elem[0]}>
-                            {elem[0] !== 'title'
-                            //  eslint-disable-next-line jsx-a11y/anchor-is-valid
-                            && <a onClick={(e) => handleErrorClick(e, elem[0])} href="#">{elem[1]}</a>}
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  </div>
-                  )}
                   <div id="firstName" className={`govuk-form-group ${errors.firstName ? 'govuk-form-group--error' : ''}`}>
                     <label className="govuk-label" htmlFor="firstNameInput">
                       Given name(s)
@@ -401,26 +377,6 @@ const PersonForm = ({ source, type }) => {
               && (
                 <>
                   <h1 className="govuk-heading-l">Travel document details</h1>
-                  {Object.keys(errors).length >= 1 && (
-                  <div className="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabIndex="-1" data-module="govuk-error-summary">
-                    <h2 className="govuk-error-summary__title">
-                      There is a problem
-                    </h2>
-                    <div className="govuk-error-summary__body">
-                      <ul className="govuk-list govuk-error-summary__list">
-                        {Object.entries(errors).reverse().map((elem) => (
-                          <li key={elem[0]}>
-                            {(elem[0] !== 'title' && elem[0] !== 'helpError')
-                            //  eslint-disable-next-line jsx-a11y/anchor-is-valid
-                            && <a onClick={(e) => handleErrorClick(e, elem[0])} href="#">{elem[1]}</a>}
-                            {elem[0] === 'helpError'
-                            && <a href="/page/help">{elem[1]}</a>}
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  </div>
-                  )}
                   <div id="pageError" className={`govuk-form-group ${errors.documentType ? 'govuk-form-group--error' : ''}`}>
                     <fieldset id="documentType" className="govuk-fieldset">
                       <legend className="govuk-fieldset__legend govuk-fieldset__legend">Select a travel document type</legend>

--- a/src/pages/people/PersonForm.jsx
+++ b/src/pages/people/PersonForm.jsx
@@ -11,6 +11,7 @@ import validate from '../../utils/validateFormData';
 import scrollToTop from '../../utils/scrollToTop';
 import nationalities from '../../utils/staticFormData';
 import PeopleValidation from './PersonValidation';
+import ErrorSummary from '../../components-v2/ErrorSummary';
 
 const PersonForm = ({ source, type }) => {
   const history = useHistory();
@@ -177,7 +178,8 @@ const PersonForm = ({ source, type }) => {
             <div className="govuk-grid-column-two-thirds">
               {formPageIs === 1
                 && (
-                <>
+                  <>
+                  <ErrorSummary errors={errors} />
                   <h1 className="govuk-heading-l">{title}</h1>
                   <div id="firstName" className={`govuk-form-group ${errors.firstName ? 'govuk-form-group--error' : ''}`}>
                     <label className="govuk-label" htmlFor="firstNameInput">
@@ -187,7 +189,8 @@ const PersonForm = ({ source, type }) => {
                     <FormFieldError error={errors.firstName} />
                     <input
                       id="firstNameInput"
-                      className="govuk-input"
+                      // Do we want input field to error too?
+                      className={`govuk-input ${errors.firstName ? 'govuk-input--error' : ''}`}
                       name="firstName"
                       type="text"
                       value={formData?.firstName || ''}
@@ -202,7 +205,7 @@ const PersonForm = ({ source, type }) => {
                     <FormFieldError error={errors.lastName} />
                     <input
                       id="lastNameInput"
-                      className="govuk-input"
+                      className={`govuk-input ${errors.lastName ? 'govuk-input--error' : ''}`}
                       name="lastName"
                       type="text"
                       value={formData?.lastName || ''}
@@ -210,7 +213,7 @@ const PersonForm = ({ source, type }) => {
                     />
                   </div>
                   <div id="dateOfBirth" className={`govuk-form-group ${errors.dateOfBirth ? 'govuk-form-group--error' : ''}`}>
-                    <label className="govuk-label" htmlFor="dateOfBirthDay">
+                    <label className="govuk-label" htmlFor="dateOfBirth">
                       Date of birth
                     </label>
                     <div id="dateOfBirth-hint" className="govuk-hint">Enter this as shown on your passport, for example, 31 03 1980</div>
@@ -218,13 +221,13 @@ const PersonForm = ({ source, type }) => {
                     <div className="govuk-date-input">
                       <div className="govuk-date-input__item">
                         <div className="govuk-form-group">
-                          <label className="govuk-label govuk-date-input__label" htmlFor="dateOfBirthDay">
+                          <label className="govuk-label govuk-date-input__label" htmlFor="dateOfBirthInput">
                             Day
                           </label>
                           <input
-                            className="govuk-input govuk-date-input__input govuk-input--width-2"
+                            className={`govuk-input govuk-date-input__input govuk-input--width-2`}
                             name="dateOfBirthDay"
-                            id="dateOfBirthDay"
+                            id="dateOfBirthInput"
                             type="text"
                             maxLength={2}
                             autoComplete="bday-day"
@@ -241,7 +244,7 @@ const PersonForm = ({ source, type }) => {
                             Month
                           </label>
                           <input
-                            className="govuk-input govuk-date-input__input govuk-input--width-2"
+                            className={`govuk-input govuk-date-input__input govuk-input--width-2`}
                             name="dateOfBirthMonth"
                             id="dateOfBirthMonth"
                             type="text"
@@ -260,7 +263,7 @@ const PersonForm = ({ source, type }) => {
                             Year
                           </label>
                           <input
-                            className="govuk-input govuk-date-input__input govuk-input--width-4"
+                            className={`govuk-input govuk-date-input__input govuk-input--width-4`}
                             name="dateOfBirthYear"
                             id="dateOfBirthYear"
                             type="text"
@@ -292,7 +295,7 @@ const PersonForm = ({ source, type }) => {
                   <div id="gender" className={`govuk-form-group ${errors.gender ? 'govuk-form-group--error' : ''}`}>
                     <fieldset className="govuk-fieldset">
                       <legend className="govuk-fieldset__legend">
-                        <label className="govuk-fieldset__heading" htmlFor="gender">
+                        <label className="govuk-fieldset__heading" htmlFor="genderInput">
                           Gender
                         </label>
                       </legend>
@@ -302,7 +305,7 @@ const PersonForm = ({ source, type }) => {
                           <input
                             className="govuk-radios__input"
                             name="gender"
-                            id="female"
+                            id="genderInput"
                             type="radio"
                             value="Female"
                             checked={formData.gender === 'Female' ? 'checked' : ''}
@@ -372,10 +375,11 @@ const PersonForm = ({ source, type }) => {
                     Exit without saving
                   </button>
                 </>
-                )}
-              {formPageIs === 2
+              )}
+            {formPageIs === 2
               && (
                 <>
+                  <ErrorSummary errors={errors} />
                   <h1 className="govuk-heading-l">Travel document details</h1>
                   <div id="pageError" className={`govuk-form-group ${errors.documentType ? 'govuk-form-group--error' : ''}`}>
                     <fieldset id="documentType" className="govuk-fieldset">
@@ -390,7 +394,7 @@ const PersonForm = ({ source, type }) => {
                         <div className="govuk-radios__item">
                           <input
                             className="govuk-radios__input"
-                            id="documentTypePassport"
+                            id="documentTypeInput"
                             name="documentType"
                             type="radio"
                             value="Passport"
@@ -398,7 +402,7 @@ const PersonForm = ({ source, type }) => {
                             onChange={handleChange}
                             data-aria-controls="documentTypePassport"
                           />
-                          <label className="govuk-label govuk-radios__label" htmlFor="documentTypePassport">
+                          <label className="govuk-label govuk-radios__label" htmlFor="documentTypeInput">
                             Passport
                           </label>
                         </div>
@@ -481,12 +485,13 @@ const PersonForm = ({ source, type }) => {
                     />
                   </div>
                   <div id="nationality" className={`govuk-form-group ${errors.nationality ? 'govuk-form-group--error' : ''}`}>
-                    <label className="govuk-label" htmlFor="nationality">
+                    <label className="govuk-label" htmlFor="nationalityInput">
                       Nationality
                     </label>
                     <FormFieldError error={errors.nationality} />
                     <select
                       data-testid="nationality-field"
+                      id="nationalityInput"
                       className="govuk-select"
                       name="nationality"
                       type="text"
@@ -509,11 +514,11 @@ const PersonForm = ({ source, type }) => {
                           <div className="govuk-date-input">
                             <div className="govuk-date-input__item">
                               <div className="govuk-form-group">
-                                <label className="govuk-label govuk-date-input__label" htmlFor="documentExpiryDateDay">Day</label>
+                                <label className="govuk-label govuk-date-input__label" htmlFor="documentExpiryDateInput">Day</label>
                                 <input
                                   className="govuk-input govuk-date-input__input govuk-input--width-2"
                                   name="documentExpiryDateDay"
-                                  id="documentExpiryDateDay"
+                                  id="documentExpiryDateInput"
                                   data-testid="documentExpiryDateDay-field"
                                   type="text"
                                   maxLength={2}

--- a/src/pages/people/PersonForm.jsx
+++ b/src/pages/people/PersonForm.jsx
@@ -190,7 +190,7 @@ const PersonForm = ({ source, type }) => {
                     <input
                       id="firstNameInput"
                       // Do we want input field to error too?
-                      className={`govuk-input ${errors.firstName ? 'govuk-input--error' : ''}`}
+                      className="govuk-input"
                       name="firstName"
                       type="text"
                       value={formData?.firstName || ''}
@@ -205,7 +205,7 @@ const PersonForm = ({ source, type }) => {
                     <FormFieldError error={errors.lastName} />
                     <input
                       id="lastNameInput"
-                      className={`govuk-input ${errors.lastName ? 'govuk-input--error' : ''}`}
+                      className="govuk-input"
                       name="lastName"
                       type="text"
                       value={formData?.lastName || ''}

--- a/src/pages/people/PersonForm.jsx
+++ b/src/pages/people/PersonForm.jsx
@@ -179,204 +179,204 @@ const PersonForm = ({ source, type }) => {
               {formPageIs === 1
                 && (
                   <>
-                  <ErrorSummary errors={errors} />
-                  <h1 className="govuk-heading-l">{title}</h1>
-                  <div id="firstName" className={`govuk-form-group ${errors.firstName ? 'govuk-form-group--error' : ''}`}>
-                    <label className="govuk-label" htmlFor="firstNameInput">
-                      Given name(s)
-                    </label>
-                    <div id="firstName-hint" className="govuk-hint">The person&apos;s first and middle names</div>
-                    <FormFieldError error={errors.firstName} />
-                    <input
-                      id="firstNameInput"
+                    <ErrorSummary errors={errors} />
+                    <h1 className="govuk-heading-l">{title}</h1>
+                    <div id="firstName" className={`govuk-form-group ${errors.firstName ? 'govuk-form-group--error' : ''}`}>
+                      <label className="govuk-label" htmlFor="firstNameInput">
+                        Given name(s)
+                      </label>
+                      <div id="firstName-hint" className="govuk-hint">The person&apos;s first and middle names</div>
+                      <FormFieldError error={errors.firstName} />
+                      <input
+                        id="firstNameInput"
                       // Do we want input field to error too?
-                      className="govuk-input"
-                      name="firstName"
-                      type="text"
-                      value={formData?.firstName || ''}
-                      onChange={handleChange}
-                    />
-                  </div>
-                  <div id="lastName" className={`govuk-form-group ${errors.lastName ? 'govuk-form-group--error' : ''}`}>
-                    <label className="govuk-label" htmlFor="lastNameInput">
-                      Surname
-                    </label>
-                    <div id="lastName-hint" className="govuk-hint">If the person has more than one surname, enter them all</div>
-                    <FormFieldError error={errors.lastName} />
-                    <input
-                      id="lastNameInput"
-                      className="govuk-input"
-                      name="lastName"
-                      type="text"
-                      value={formData?.lastName || ''}
-                      onChange={handleChange}
-                    />
-                  </div>
-                  <div id="dateOfBirth" className={`govuk-form-group ${errors.dateOfBirth ? 'govuk-form-group--error' : ''}`}>
-                    <label className="govuk-label" htmlFor="dateOfBirth">
-                      Date of birth
-                    </label>
-                    <div id="dateOfBirth-hint" className="govuk-hint">Enter this as shown on your passport, for example, 31 03 1980</div>
-                    <FormFieldError error={errors.dateOfBirth} />
-                    <div className="govuk-date-input">
-                      <div className="govuk-date-input__item">
-                        <div className="govuk-form-group">
-                          <label className="govuk-label govuk-date-input__label" htmlFor="dateOfBirthInput">
-                            Day
-                          </label>
-                          <input
-                            className={`govuk-input govuk-date-input__input govuk-input--width-2`}
-                            name="dateOfBirthDay"
-                            id="dateOfBirthInput"
-                            type="text"
-                            maxLength={2}
-                            autoComplete="bday-day"
-                            pattern="[0-9]*"
-                            inputMode="numeric"
-                            value={formData?.dateOfBirthDay || ''}
-                            onChange={handleChange}
-                          />
+                        className="govuk-input"
+                        name="firstName"
+                        type="text"
+                        value={formData?.firstName || ''}
+                        onChange={handleChange}
+                      />
+                    </div>
+                    <div id="lastName" className={`govuk-form-group ${errors.lastName ? 'govuk-form-group--error' : ''}`}>
+                      <label className="govuk-label" htmlFor="lastNameInput">
+                        Surname
+                      </label>
+                      <div id="lastName-hint" className="govuk-hint">If the person has more than one surname, enter them all</div>
+                      <FormFieldError error={errors.lastName} />
+                      <input
+                        id="lastNameInput"
+                        className="govuk-input"
+                        name="lastName"
+                        type="text"
+                        value={formData?.lastName || ''}
+                        onChange={handleChange}
+                      />
+                    </div>
+                    <div id="dateOfBirth" className={`govuk-form-group ${errors.dateOfBirth ? 'govuk-form-group--error' : ''}`}>
+                      <label className="govuk-label" htmlFor="dateOfBirth">
+                        Date of birth
+                      </label>
+                      <div id="dateOfBirth-hint" className="govuk-hint">Enter this as shown on your passport, for example, 31 03 1980</div>
+                      <FormFieldError error={errors.dateOfBirth} />
+                      <div className="govuk-date-input">
+                        <div className="govuk-date-input__item">
+                          <div className="govuk-form-group">
+                            <label className="govuk-label govuk-date-input__label" htmlFor="dateOfBirthInput">
+                              Day
+                            </label>
+                            <input
+                              className="govuk-input govuk-date-input__input govuk-input--width-2"
+                              name="dateOfBirthDay"
+                              id="dateOfBirthInput"
+                              type="text"
+                              maxLength={2}
+                              autoComplete="bday-day"
+                              pattern="[0-9]*"
+                              inputMode="numeric"
+                              value={formData?.dateOfBirthDay || ''}
+                              onChange={handleChange}
+                            />
+                          </div>
                         </div>
-                      </div>
-                      <div className="govuk-date-input__item">
-                        <div className="govuk-form-group">
-                          <label className="govuk-label govuk-date-input__label" htmlFor="dateOfBirthMonth">
-                            Month
-                          </label>
-                          <input
-                            className={`govuk-input govuk-date-input__input govuk-input--width-2`}
-                            name="dateOfBirthMonth"
-                            id="dateOfBirthMonth"
-                            type="text"
-                            maxLength={2}
-                            autoComplete="bday-month"
-                            pattern="[0-9]*"
-                            inputMode="numeric"
-                            value={formData?.dateOfBirthMonth || ''}
-                            onChange={handleChange}
-                          />
+                        <div className="govuk-date-input__item">
+                          <div className="govuk-form-group">
+                            <label className="govuk-label govuk-date-input__label" htmlFor="dateOfBirthMonth">
+                              Month
+                            </label>
+                            <input
+                              className="govuk-input govuk-date-input__input govuk-input--width-2"
+                              name="dateOfBirthMonth"
+                              id="dateOfBirthMonth"
+                              type="text"
+                              maxLength={2}
+                              autoComplete="bday-month"
+                              pattern="[0-9]*"
+                              inputMode="numeric"
+                              value={formData?.dateOfBirthMonth || ''}
+                              onChange={handleChange}
+                            />
+                          </div>
                         </div>
-                      </div>
-                      <div className="govuk-date-input__item">
-                        <div className="govuk-form-group">
-                          <label className="govuk-label" htmlFor="dateOfBirthYear">
-                            Year
-                          </label>
-                          <input
-                            className={`govuk-input govuk-date-input__input govuk-input--width-4`}
-                            name="dateOfBirthYear"
-                            id="dateOfBirthYear"
-                            type="text"
-                            maxLength={4}
-                            autoComplete="bday-year"
-                            pattern="[0-9]*"
-                            inputMode="numeric"
-                            value={formData?.dateOfBirthYear || ''}
-                            onChange={handleChange}
-                          />
+                        <div className="govuk-date-input__item">
+                          <div className="govuk-form-group">
+                            <label className="govuk-label" htmlFor="dateOfBirthYear">
+                              Year
+                            </label>
+                            <input
+                              className="govuk-input govuk-date-input__input govuk-input--width-4"
+                              name="dateOfBirthYear"
+                              id="dateOfBirthYear"
+                              type="text"
+                              maxLength={4}
+                              autoComplete="bday-year"
+                              pattern="[0-9]*"
+                              inputMode="numeric"
+                              value={formData?.dateOfBirthYear || ''}
+                              onChange={handleChange}
+                            />
+                          </div>
                         </div>
                       </div>
                     </div>
-                  </div>
-                  <div id="placeOfBirth" className={`govuk-form-group ${errors.placeOfBirth ? 'govuk-form-group--error' : ''}`}>
-                    <label className="govuk-label" htmlFor="placeOfBirthInput">
-                      Place of birth
-                    </label>
-                    <FormFieldError error={errors.placeOfBirth} />
-                    <input
-                      id="placeOfBirthInput"
-                      className="govuk-input"
-                      name="placeOfBirth"
-                      type="text"
-                      value={formData?.placeOfBirth || ''}
-                      onChange={handleChange}
-                    />
-                  </div>
-                  <div id="gender" className={`govuk-form-group ${errors.gender ? 'govuk-form-group--error' : ''}`}>
-                    <fieldset className="govuk-fieldset">
-                      <legend className="govuk-fieldset__legend">
-                        <label className="govuk-fieldset__heading" htmlFor="genderInput">
-                          Gender
-                        </label>
-                      </legend>
-                      <div className="govuk-radios govuk-radios">
-                        <FormFieldError error={errors.gender} />
-                        <div className="govuk-radios__item">
-                          <input
-                            className="govuk-radios__input"
-                            name="gender"
-                            id="genderInput"
-                            type="radio"
-                            value="Female"
-                            checked={formData.gender === 'Female' ? 'checked' : ''}
-                            onChange={handleChange}
-                          />
-                          <label className="govuk-label govuk-radios__label" htmlFor="female">
-                            Female
+                    <div id="placeOfBirth" className={`govuk-form-group ${errors.placeOfBirth ? 'govuk-form-group--error' : ''}`}>
+                      <label className="govuk-label" htmlFor="placeOfBirthInput">
+                        Place of birth
+                      </label>
+                      <FormFieldError error={errors.placeOfBirth} />
+                      <input
+                        id="placeOfBirthInput"
+                        className="govuk-input"
+                        name="placeOfBirth"
+                        type="text"
+                        value={formData?.placeOfBirth || ''}
+                        onChange={handleChange}
+                      />
+                    </div>
+                    <div id="gender" className={`govuk-form-group ${errors.gender ? 'govuk-form-group--error' : ''}`}>
+                      <fieldset className="govuk-fieldset">
+                        <legend className="govuk-fieldset__legend">
+                          <label className="govuk-fieldset__heading" htmlFor="genderInput">
+                            Gender
                           </label>
+                        </legend>
+                        <div className="govuk-radios govuk-radios">
+                          <FormFieldError error={errors.gender} />
+                          <div className="govuk-radios__item">
+                            <input
+                              className="govuk-radios__input"
+                              name="gender"
+                              id="genderInput"
+                              type="radio"
+                              value="Female"
+                              checked={formData.gender === 'Female' ? 'checked' : ''}
+                              onChange={handleChange}
+                            />
+                            <label className="govuk-label govuk-radios__label" htmlFor="female">
+                              Female
+                            </label>
+                          </div>
+                          <div className="govuk-radios__item">
+                            <input
+                              className="govuk-radios__input"
+                              name="gender"
+                              id="male"
+                              type="radio"
+                              value="Male"
+                              checked={formData.gender === 'Male' ? 'checked' : ''}
+                              onChange={handleChange}
+                            />
+                            <label className="govuk-label govuk-radios__label" htmlFor="male">
+                              Male
+                            </label>
+                          </div>
+                          <div className="govuk-radios__item">
+                            <input
+                              className="govuk-radios__input"
+                              name="gender"
+                              id="non-binary"
+                              type="radio"
+                              value="Non-binary"
+                              checked={formData.gender === 'Non-binary' ? 'checked' : ''}
+                              onChange={handleChange}
+                            />
+                            <label className="govuk-label govuk-radios__label" htmlFor="non-binary">
+                              Non-binary
+                            </label>
+                          </div>
                         </div>
-                        <div className="govuk-radios__item">
-                          <input
-                            className="govuk-radios__input"
-                            name="gender"
-                            id="male"
-                            type="radio"
-                            value="Male"
-                            checked={formData.gender === 'Male' ? 'checked' : ''}
-                            onChange={handleChange}
-                          />
-                          <label className="govuk-label govuk-radios__label" htmlFor="male">
-                            Male
-                          </label>
-                        </div>
-                        <div className="govuk-radios__item">
-                          <input
-                            className="govuk-radios__input"
-                            name="gender"
-                            id="non-binary"
-                            type="radio"
-                            value="Non-binary"
-                            checked={formData.gender === 'Non-binary' ? 'checked' : ''}
-                            onChange={handleChange}
-                          />
-                          <label className="govuk-label govuk-radios__label" htmlFor="non-binary">
-                            Non-binary
-                          </label>
-                        </div>
-                      </div>
-                    </fieldset>
-                  </div>
-                  <div className="govuk-button-group">
+                      </fieldset>
+                    </div>
+                    <div className="govuk-button-group">
+                      <button
+                        type="button"
+                        className="govuk-button"
+                        data-module="govuk-button"
+                        onClick={(e) => {
+                          goToNextPage(e, { url: 'nextFormPageIs', runValidation: true });
+                        }}
+                      >
+                        Continue
+                      </button>
+                      {type === 'edit' && (
+                      <button
+                        type="button"
+                        className="govuk-button govuk-button--warning"
+                        onClick={(e) => { goToNextPage(e, { url: `/people/${personId}/delete`, runValidation: false }); }}
+                      >
+                        Delete this person
+                      </button>
+                      )}
+                    </div>
                     <button
                       type="button"
-                      className="govuk-button"
-                      data-module="govuk-button"
-                      onClick={(e) => {
-                        goToNextPage(e, { url: 'nextFormPageIs', runValidation: true });
-                      }}
+                      className="govuk-button govuk-button--text"
+                      onClick={(e) => { goToNextPage(e, { url: sourcePage, runValidation: false }); }}
                     >
-                      Continue
+                      Exit without saving
                     </button>
-                    {type === 'edit' && (
-                    <button
-                      type="button"
-                      className="govuk-button govuk-button--warning"
-                      onClick={(e) => { goToNextPage(e, { url: `/people/${personId}/delete`, runValidation: false }); }}
-                    >
-                      Delete this person
-                    </button>
-                    )}
-                  </div>
-                  <button
-                    type="button"
-                    className="govuk-button govuk-button--text"
-                    onClick={(e) => { goToNextPage(e, { url: sourcePage, runValidation: false }); }}
-                  >
-                    Exit without saving
-                  </button>
-                </>
-              )}
-            {formPageIs === 2
+                  </>
+                )}
+              {formPageIs === 2
               && (
                 <>
                   <ErrorSummary errors={errors} />


### PR DESCRIPTION
### AC / Description of changes
Move the error summary object into its own component, rather than have it repeated for each form in the application. Implement a method that scrolls to label but focuses on the correct input so the user can start inputing the information immediately. 

Add this component to the people form and refactor some code.

### To Test
- Go to the people tab
- Click the continue button
- All the fields should error
- Click the links in the error summary
- It should scroll to the label and focus on the input
- Fill out the info and continue to the second page
- Click save and all fields should error and the links should work the same as page 1

### Notes

---
* remember to merge to feature branches not master *


