### PR TITLE
SPCR-377 Add missing variable to webpack.config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,7 @@ module.exports = {
     new webpack.EnvironmentPlugin({
       SGMR_DATA_API_BASE_URL: 'http://localhost:5000/v1',
       SGMR_MAINTENANCE: false,
+      GOV_NOTIFY_SUPPORT_EMAIL: 'testemail@email.com', // for testing purposes you can replace with a personal email address
     }),
     new HtmlWebpackPlugin({ template: './index.html' }),
   ],


### PR DESCRIPTION
### AC / Description of changes
Currently the code is not working locally or on dev because of a missing variable in the webpack config. Add this missing variable to the code so that the code will load without errors. 

### To Test
- Run `npm start`
- The application should load correctly and work as expected

### Notes

---
* remember to merge to feature branches not master *


