### PR TITLE
SPCR-380 Fix telephone validation issue in EditAccount

### DIFF
--- a/src/components/User/EditAccount.jsx
+++ b/src/components/User/EditAccount.jsx
@@ -58,11 +58,10 @@ const EditAccount = () => {
     validationRules.map((elem) => {
       if (!(elem.field in formData) || formData[elem.field] === '') {
         tempObj[elem.field] = elem.message;
+      } else if (!(VALID_INTERNATIONAL_MOBILE_REGEX.test(formData.mobileNumber))) {
+        tempObj.mobileNumber = 'You must enter a valid telephone number e.g. 07700 900982, +33 63998 010101';
       } else {
         return null;
-      }
-      if (!(VALID_INTERNATIONAL_MOBILE_REGEX.test(formData.mobileNumber))) {
-        tempObj.mobileNumber = 'You must enter a valid telephone number e.g. 07700 900982, +33 63998 010101';
       }
     });
     setErrors(tempObj);


### PR DESCRIPTION
### AC / Description of changes
> There is a bug currently where a user can type an invalid phone number into the Edit Account page and it will successfully save without throwing an error.
The validation has been successfully implemented before, so this needs to be investigated and fixed.

This telephone number validation issue in the Edit Account page has now been fixed.

### To Test
- Sign in
- Go to Edit Account
- Type in an invalid phone number
- Click save and continue
- You should get an error
- Type in a valid phone number
- Click save and continue
- You should be redirected to the account page

### Notes

---
* remember to merge to feature branches not master *


