### PR TITLE
SPCR-304 Refactor autocomplete tests

### DIFF
--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -123,6 +123,7 @@ const Nav = (urlStem) => {
             })}
             <li className="govuk-header__navigation-item">
               <a href="#sign-out" className="govuk-header__link" onClick={() => handleSignout()}>Sign out</a>
+              {/* Link tag cannot be used as we do not have a signout route */}
             </li>
           </ul>
         </nav>

--- a/src/components/PortField.jsx
+++ b/src/components/PortField.jsx
@@ -46,7 +46,7 @@ const PortField = ({
       setOtherValue(''); // user selects from the autoselect
       setPortList([]);
     } else {
-      setSearchTerm(''); // user is typing in the 'other' field
+      setSearchTerm(value); // user is typing in the 'other' field
       setOtherValue(value);
       setPortEntered({ name: value, unlocode: null });
     }
@@ -77,14 +77,14 @@ const PortField = ({
     <>
       <Combobox
         id="portsCombobox"
-        data-testid="portContainer"
+        data-testid="port"
         aria-label="Begin typing for port selections to appear"
         onSelect={(e) => handlePortSelection(e)}
       >
         <ComboboxInput
           id="autocomplete"
           className="govuk-input"
-          data-testid="port"
+          data-testid="portInput"
           name={`autocomplete${fieldName}`}
           onChange={handleSearchTermChange}
           value={searchTerm}

--- a/src/components/Voyage/__tests__/FormArrival.test.jsx
+++ b/src/components/Voyage/__tests__/FormArrival.test.jsx
@@ -18,6 +18,6 @@ describe('FormArrival', () => {
     expect(screen.getByText('Intended arrival details')).toBeInTheDocument();
     expect(screen.getAllByRole('textbox').length).toBe(6); // day, month, year, hour, minute
     expect(screen.getAllByRole('combobox').length).toBe(1); // port
-    expect(screen.getByTestId('portContainer')).toHaveAttribute('id', 'portsCombobox');
+    expect(screen.getByTestId('port')).toHaveAttribute('id', 'portsCombobox');
   });
 });

--- a/src/components/Voyage/__tests__/FormDeparture.test.jsx
+++ b/src/components/Voyage/__tests__/FormDeparture.test.jsx
@@ -18,6 +18,6 @@ describe('FormDeparture', () => {
     expect(screen.getByText('Intended departure details')).toBeInTheDocument();
     expect(screen.getAllByRole('textbox').length).toBe(6); // day, month, year, hour, minute
     expect(screen.getAllByRole('combobox').length).toBe(1); // port
-    expect(screen.getByTestId('portContainer')).toHaveAttribute('id', 'portsCombobox');
+    expect(screen.getByTestId('port')).toHaveAttribute('id', 'portsCombobox');
   });
 });

--- a/src/components/__tests__/PortField.test.jsx
+++ b/src/components/__tests__/PortField.test.jsx
@@ -6,12 +6,8 @@ import {
   waitFor,
   fireEvent,
 } from '@testing-library/react';
-// import userEvent from '@testing-library/user-event';
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
 
 import PortField from '../PortField';
-// import { PORTS_URL } from '../../constants/ApiConstants';
 
 jest.mock('lodash.debounce', () => (fn) => {
   fn.debounce = jest.fn();
@@ -19,70 +15,27 @@ jest.mock('lodash.debounce', () => (fn) => {
 });
 
 describe('PortField', () => {
-  const mockAxios = new MockAdapter(axios);
-
   beforeEach(() => {
-    mockAxios.reset();
+    render(<PortField />);
   });
 
-  // it('should render ports in the autosuggest field when we have suggestions', async () => {
-  //   mockAxios
-  //     .onGet(`${PORTS_URL}?name=test`)
-  //    .reply(200, [
-  //       {
-  //         name: 'TEST_NAME',
-  //         unlocode: 'TEST_UNLOCODE',
-  //       },
-  //       {
-  //         name: 'TEST_FOO',
-  //         unlocode: 'BAR',
-  //       },
-  //       {
-  //         name: 'TEST_NO_UNLOCODE',
-  //         unlocode: null,
-  //       },
-  //     ]);
-
-  //  render(<PortField />);
-
-  //  await waitFor(() => fireEvent.change(screen.getByRole('combobox'), { target: { value: 'TEST_FOO' } }));
-
-  //   expect(mockAxios.history.get.length).toBe(2);
-  //   expect(screen.queryByText('TEST_NAME (TEST_UNLOCODE)')).toBeInTheDocument();
-  //   expect(screen.queryByText('TEST_FOO (BAR)')).toBeInTheDocument();
-  //   expect(screen.queryByText('TEST_NO_UNLOCODE')).toBeInTheDocument();
-  // });
-
   it('should allow user to enter a location in a free text field if they click cannot find location in list', async () => {
-    render(<PortField />);
     expect(screen.getByTestId('portOther')).not.toBeVisible();
+
     await waitFor(() => fireEvent.click(screen.getByText('I cannot find the location in the list')));
     expect(screen.getByTestId('portOther')).toBeVisible();
     expect(screen.getByTestId('portOtherInput')).toBeVisible();
+
     fireEvent.change(screen.getByTestId('portOtherInput'), { target: { value: 'TEST' } });
     expect(screen.getByTestId('portOtherInput').value).toBe('TEST');
   });
 
-  // it('should clear the value of combo box when optional field entered and vice versa', async () => {
-  //   mockAxios
-  //     .onGet(`${PORTS_URL}?name=test`)
-  //     .reply(200, [
-  //       {
-  //         name: 'TEST_NAME',
-  //         unlocode: null,
-  //       },
-  //     ]);
+  it('should mirror the input of the the free text field on the combobox input when the free text field input changed', async () => {
+    expect(screen.getByTestId('portOther')).not.toBeVisible();
+    fireEvent.change(screen.getByTestId('portInput'), { target: { value: 'OTHER_VALUE' } });
 
-  //   render(<PortField />);
-
-  //   expect(screen.getByTestId('portOther')).not.toBeVisible();
-  //   fireEvent.change(screen.getByTestId('port'), { target: { value: 'TEST2' } });
-  //   await waitFor(() => fireEvent.click(screen.getByText('I cannot find the location in the list')));
-  //   fireEvent.change(screen.getByTestId('portOtherInput'), { target: { value: 'TEST' } });
-  //   expect(screen.getByTestId('port').value).toBe('');
-
-  //   fireEvent.change(screen.getByTestId('port'), { target: { value: 'test' } });
-  //   userEvent.selectOptions(screen.getByTestId('portContainer'), 'TEST_NAME');
-  //  expect(screen.getByTestId('portOtherInput').value).toBe('');
-  // });
+    await waitFor(() => fireEvent.click(screen.getByText('I cannot find the location in the list')));
+    fireEvent.change(screen.getByTestId('portOtherInput'), { target: { value: 'TEST' } });
+    expect(screen.getByTestId('portInput').value).toBe('TEST');
+  });
 });


### PR DESCRIPTION
### AC / Description of changes
> Unit testing for the autocomplete component needs to be implemented, and we should investigate the best way to go about doing this.

Uncommented PortField tests and refactored them into passing.

### To Test
- `npm test`
- All tests should pass
- `npm run lint`
- Should be presented with no errors (1 warning which is unrelated to the scope of this ticket)
- Should also successfully compile and run with 'npm start`
- Check through code changes

### Notes
- Certain tests were deleted as we cannot mock an onSelect action for the combobox. These test cases will be covered by the end to end tests


---
* remember to merge to feature branches not master *


