### PR TITLE
SPCR-257 Edit pleasure craft

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -19,15 +19,13 @@ import AccessibilityStatement from './AccessibilityStatement';
 import PageContainer from './PageContainer';
 
 import PersonForm from '../pages/people/PersonForm';
+import PleasureCraftForm from '../pages/pleasureCrafts/PleasureCraftForm';
 
 import SignIn from './User/SignIn';
 import UserRegister from './User/UserRegister';
 import EditAccount from './User/EditAccount';
 import UserRegisterConfirmation from './User/UserRegisterConfirmation';
 import AccountActivation from './User/AccountActivation';
-
-import EditVessel from './Vessel/EditVessel';
-import PleasureCraftForm from '../pages/pleasureCrafts/PleasureCraftForm';
 
 import VoyageFormContainer from './Voyage/VoyageFormContainer';
 import FormVoyageSubmitted from './Forms/FormVoyageSubmitted';
@@ -103,8 +101,8 @@ const Main = () => {
             <SecureRoute exact path="/pleasure-crafts/save-pleasure-craft/page-([1-2]{1})">
               <PleasureCraftForm />
             </SecureRoute>
-            <SecureRoute exact path="/pleasure-crafts/:vesselId">
-              <EditVessel />
+            <SecureRoute exact path="/pleasure-crafts/edit-pleasure-craft/page-([1-2]{1})">
+              <PleasureCraftForm type="edit" />
             </SecureRoute>
             <SecureRoute exact path="/pleasure-crafts/:entityId/delete">
               <ActionEntity

--- a/src/components/Vessel/VesselTable.jsx
+++ b/src/components/Vessel/VesselTable.jsx
@@ -45,8 +45,11 @@ const VesselTable = ({
                   </span>
                   <Link
                     className="govuk-link"
-                    to={`/pleasure-crafts/${vessel.id}`}
-                    aria-label={`Edit the ${vessel.vesselType} named ${vessel.vesselName}`}
+                    to={{
+                      pathname: '/pleasure-crafts/edit-pleasure-craft/page-1',
+                      state: { pleasureCraftId: vessel.id, source: 'edit' },
+                    }}
+                    aria-label={`Edit ${vessel.vesselType} named ${vessel.vesselName}`}
                   >
                     {vessel.vesselName}
                   </Link>

--- a/src/pages/pleasureCrafts/PleasureCraftForm.jsx
+++ b/src/pages/pleasureCrafts/PleasureCraftForm.jsx
@@ -134,21 +134,21 @@ const PleasureCraftForm = ({ source, type }) => {
   useEffect(() => {
     switch (sourceLocation) {
       case 'onboarding':
-        setTitle('Add details of a person you frequently sail with');
+        setTitle('Add a pleasure craft');
         setSubmitType('POST');
         break;
       case 'voyage':
-        setTitle('Add details of the person you are sailing with');
+        setTitle('Add a pleasure craft');
         setSubmitType('POST');
         break;
       case 'edit':
-        setTitle('Update details of the person you sail with');
+        setTitle('Update details of your pleasure craft');
         setSubmitType('PATCH');
         setSubmittedNextPage(PLEASURE_CRAFT_PAGE_URL);
         setSourcePage(PLEASURE_CRAFT_PAGE_URL);
         break;
       default:
-        setTitle('Add details of the person you frequently sail with');
+        setTitle('Add a pleasure craft');
         setSubmitType('POST');
         setSubmittedNextPage(PLEASURE_CRAFT_PAGE_URL);
         setSourcePage(PLEASURE_CRAFT_PAGE_URL);
@@ -307,6 +307,15 @@ const PleasureCraftForm = ({ source, type }) => {
                       >
                         Continue
                       </button>
+                      {type === 'edit' && (
+                      <button
+                        type="button"
+                        className="govuk-button govuk-button--warning"
+                        onClick={(e) => { goToNextPage(e, { url: `/pleasure-crafts/${pleasureCraftId}/delete`, runValidation: false }); }}
+                      >
+                        Delete this pleasure craft
+                      </button>
+                      )}
                     </div>
                     <button
                       type="button"
@@ -385,6 +394,7 @@ const PleasureCraftForm = ({ source, type }) => {
                           <label className="govuk-label" htmlFor="registrationCountryName">
                             Country of registration
                             <input
+                              id="registrationCountryName"
                               className="govuk-input"
                               name="registrationCountryName"
                               type="text"

--- a/src/pages/pleasureCrafts/__tests__/PleasureCraftForm.test.jsx
+++ b/src/pages/pleasureCrafts/__tests__/PleasureCraftForm.test.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Router } from 'react-router-dom';
 import {
   fireEvent, render, screen, waitFor,
 } from '@testing-library/react';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 // eslint-disable-next-line import/no-extraneous-dependencies
+import { createMemoryHistory } from 'history';
+import { PLEASURE_CRAFT_URL } from '../../../constants/ApiConstants';
 import PleasureCraftForm from '../PleasureCraftForm';
 
 const renderPage = ({
@@ -18,7 +20,7 @@ const renderPage = ({
   );
 };
 
-describe('Creating and editing people', () => {
+describe('Creating and editing pleasure craft', () => {
   const mockAxios = new MockAdapter(axios);
 
   beforeEach(() => {
@@ -26,35 +28,45 @@ describe('Creating and editing people', () => {
     window.sessionStorage.removeItem('formData');
   });
 
-  // it('should render different titles based on where the user comes from', () => {
-  //   const testTitle = (text) => {
-  //     expect(screen.getByText(text).outerHTML).toEqual(`<h1 class="govuk-heading-l">${text}</h1>`);
-  //   };
+  it('should render title based on user coming from onboarding', () => {
+    const testTitle = (text) => {
+      expect(screen.getByText(text).outerHTML).toEqual(`<h1 class="govuk-heading-l">${text}</h1>`);
+    };
+    renderPage({ pageNumber: 1, source: 'onboarding' });
+    testTitle('Add a pleasure craft');
+    renderPage({ pageNumber: 2, source: 'onboarding' });
+    testTitle('Add a pleasure craft');
+  });
 
-  //   renderPage({ pageNumber: 1, source: 'onboarding' });
-  //   testTitle('Add a pleasure craft');
+  it('should render title based on user coming from voyage', () => {
+    const testTitle = (text) => {
+      expect(screen.getByText(text).outerHTML).toEqual(`<h1 class="govuk-heading-l">${text}</h1>`);
+    };
+    renderPage({ pageNumber: 1, source: 'voyage' });
+    testTitle('Add a pleasure craft');
+    renderPage({ pageNumber: 2, source: 'voyage' });
+    testTitle('Add a pleasure craft');
+  });
 
-  //   renderPage({ pageNumber: 2, source: 'onboarding' });
-  //   testTitle('Add a pleasure craft');
+  it('should render title based on user coming from edit', () => {
+    const testTitle = (text) => {
+      expect(screen.getByText(text).outerHTML).toEqual(`<h1 class="govuk-heading-l">${text}</h1>`);
+    };
+    renderPage({ pageNumber: 1, source: 'edit' });
+    testTitle('Update details of your pleasure craft');
+    renderPage({ pageNumber: 2, source: 'edit' });
+    testTitle('Update details of your pleasure craft');
+  });
 
-  //   renderPage({ pageNumber: 1, source: 'voyage' });
-  //   testTitle('Add a pleasure craft');
-
-  //   renderPage({ pageNumber: 2, source: 'voyage' });
-  //   testTitle('Add a pleasure craft');
-
-  //   renderPage({ pageNumber: 1, source: 'edit' });
-  //   testTitle('Update details of a pleasure craft');
-
-  //   renderPage({ pageNumber: 2, source: 'edit' });
-  //   testTitle('Update details of a pleasure craft');
-
-  //   renderPage({ pageNumber: 1 });
-  //   testTitle('Add a pleasure craft');
-
-  //   renderPage({ pageNumber: 2 });
-  //   testTitle('Add a pleasure craft');
-  // });
+  it('should render title based on user coming from anywhere else', () => {
+    const testTitle = (text) => {
+      expect(screen.getByText(text).outerHTML).toEqual(`<h1 class="govuk-heading-l">${text}</h1>`);
+    };
+    renderPage({ pageNumber: 1 });
+    testTitle('Add a pleasure craft');
+    renderPage({ pageNumber: 2 });
+    testTitle('Add a pleasure craft');
+  });
 
   it('should render errors on continue if fields on page 1 are empty', async () => {
     renderPage({ pageNumber: 1 });
@@ -148,5 +160,120 @@ describe('Creating and editing people', () => {
     renderPage({ pageNumber: 1 });
     await waitFor(() => fireEvent.click(screen.getByText('Exit without saving')));
     expect(screen.queryAllByText('There is a problem')).toHaveLength(0);
+  });
+
+  it('should store form data in the session for use on refresh', async () => {
+    const expectedPage1FormData = '{"pleasureCraftName":"Moonfish","type":"Sailing boat","mooring":"London"}';
+    // eslint-disable-next-line max-len
+    const expectedPage2FormData = '{"pleasureCraftName":"Moonfish","type":"Sailing boat","mooring":"London","registrationNumber":"Moonfish123","registrationCountry":"registrationCountryYes","registrationCountryName":"GBR","callSign":"callSignYes","callSignReference":"MoonMoon"}';
+    renderPage({ pageNumber: 1 });
+    fireEvent.change(screen.getByLabelText('Name of pleasure craft'), { target: { value: 'Moonfish' } });
+    fireEvent.click(screen.getByLabelText('Sailing boat (with or without an engine)'));
+    fireEvent.change(screen.getByLabelText('Usual moorings'), { target: { value: 'London' } });
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedPage1FormData);
+
+    renderPage({ pageNumber: 2 });
+    fireEvent.change(screen.getByLabelText('Registration number'), { target: { value: 'Moonfish123' } });
+    fireEvent.click(screen.getByTestId('registrationCountryYes'));
+    fireEvent.change(screen.getByLabelText('Country of registration'), { target: { value: 'GBR' } });
+    fireEvent.click(screen.getByTestId('callSignYes'));
+    fireEvent.change(screen.getByLabelText('Call sign'), { target: { value: 'MoonMoon' } });
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedPage2FormData);
+  });
+
+  it('should prefill person details if type is edit', async () => {
+    const history = createMemoryHistory();
+    const state = { pleasureCraftId: 'craft123', source: 'edit' };
+    history.push('/pleasure-crafts/edit-pleasure-craft/page-1', state);
+    mockAxios
+      .onGet(`${PLEASURE_CRAFT_URL}/craft123`)
+      .reply(200, {
+        id: '123',
+        vesselName: 'CraftOne',
+        registration: 'ABCCraftOne',
+        hullIdentificationNumber: '',
+        vesselType: 'Sailing boat',
+        portOfRegistry: '',
+        vesselNationality: 'GBR',
+        moorings: 'London',
+        callsign: 'Bobscraft',
+      });
+
+    await waitFor(() => {
+      render(
+        <Router history={history}>
+          <PleasureCraftForm type="edit" source="edit" />
+        </Router>,
+      );
+    });
+
+    expect(screen.getByText('Update details of your pleasure craft').outerHTML).toEqual('<h1 class="govuk-heading-l">Update details of your pleasure craft</h1>');
+    expect(screen.getByDisplayValue('CraftOne')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Sailing boat')).toBeChecked();
+    expect(screen.getByDisplayValue('London')).toBeInTheDocument();
+
+    await waitFor(() => {
+      renderPage({
+        type: 'edit', source: 'edit', pageNumber: 2,
+      });
+    });
+    expect(screen.getByDisplayValue('ABCCraftOne')).toBeInTheDocument();
+    expect(screen.getByTestId('callSignYes')).toBeChecked();
+    expect(screen.getByDisplayValue('GBR')).toBeInTheDocument();
+    expect(screen.getByTestId('registrationCountryYes')).toBeChecked();
+    expect(screen.getByDisplayValue('Bobscraft')).toBeInTheDocument();
+  });
+
+  it('should prefill person details if type is edit - and not fill optional fields if they are empty', async () => {
+    const history = createMemoryHistory();
+    const state = { pleasureCraftId: 'craft123', source: 'edit' };
+    history.push('/pleasure-crafts/edit-pleasure-craft/page-1', state);
+    mockAxios
+      .onGet(`${PLEASURE_CRAFT_URL}/craft123`)
+      .reply(200, {
+        id: '123',
+        vesselName: 'CraftOne',
+        registration: 'ABCCraftOne',
+        hullIdentificationNumber: '',
+        vesselType: 'Sailing boat',
+        portOfRegistry: '',
+        vesselNationality: '',
+        moorings: 'London',
+        callsign: '',
+      });
+
+    await waitFor(() => {
+      render(
+        <Router history={history}>
+          <PleasureCraftForm type="edit" source="edit" />
+        </Router>,
+      );
+    });
+
+    expect(screen.getByText('Update details of your pleasure craft').outerHTML).toEqual('<h1 class="govuk-heading-l">Update details of your pleasure craft</h1>');
+    expect(screen.getByDisplayValue('CraftOne')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Sailing boat')).toBeChecked();
+    expect(screen.getByDisplayValue('London')).toBeInTheDocument();
+
+    await waitFor(() => {
+      renderPage({
+        type: 'edit', source: 'edit', pageNumber: 2,
+      });
+    });
+    expect(screen.getByDisplayValue('ABCCraftOne')).toBeInTheDocument();
+    expect(screen.getByTestId('callSignYes')).not.toBeChecked();
+    expect(screen.getByTestId('registrationCountryYes')).not.toBeChecked();
+    expect(screen.queryByText('Call sign')).not.toBeInTheDocument();
+    expect(screen.queryByText('Country of registration')).not.toBeInTheDocument();
+  });
+
+  it('should show a delete option if you are in edit type', async () => {
+    renderPage({ type: 'edit', source: 'edit', pageNumber: 1 });
+    expect(screen.getByText('Delete this pleasure craft')).toBeInTheDocument();
+  });
+
+  it('should show NOT a delete option if you are NOT in edit type', async () => {
+    renderPage({ pageNumber: 1 });
+    expect(screen.queryByText('Delete this pleasure craft')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### AC / Description of changes

Update pleasure craft form to handle edit and delete cases


### To Test

- go to /pleasure-crafts
- save a new pleasure craft, ensuring you choose `motorboat`, `no - country of registration`, `no - callsign`

- click the pc you created
- > you should be taken to the pc form with the fields prefilled
- > the 'other' field for pc type should be hidden
- select `other` for pc type
- continue
- > you should see the page 2 fields prefilled
- > you should not see the country of registration or call sign text input fields
- change country of registration to `yes`
- change call sign to `yes`
- save
- > you should be returned to the list of pleasure crafts

- click the pc you just edited
- > you should be taken to page 1 with fields pre-filled, including the other text field
- check type to motorboat
- click continue
- > you should be taken to page 2 with fields pre-filled, including country of registration and callsign
- change country of registration to `no`
- change callsign to `no`
- save
- > you should be returned to the list of pleasure crafts

- click the pc you just edited
- > you should be taken to the pc form with the fields prefilled
- > the 'other' field for pc type should be hidden
- continue
- > you should see the page 2 fields prefilled
- > you should not see the country of registration or call sign text input fields

- make a change on this page
- click exit without saving
- you should be returned to your list of pc
- click on the pc you just exited from
- you should not see the changes that you did not save
- click on delete
- you should be asked if you're sure you want to delete


### Notes

---
* remember to merge to feature branches not master *


