### PR TITLE
SPCR-381 Implement the ErrorSummary into the pleasure craft form

### DIFF
--- a/src/pages/pleasureCrafts/PleasureCraftForm.jsx
+++ b/src/pages/pleasureCrafts/PleasureCraftForm.jsx
@@ -10,6 +10,7 @@ import removeError from '../../utils/errorHandlers';
 import scrollToTop from '../../utils/scrollToTop';
 import validate from '../../utils/validateFormData';
 import PleasureCraftValidation from './PleasureCraftValidation';
+import ErrorSummary from '../../components-v2/ErrorSummary';
 
 const PleasureCraftForm = ({ source, type }) => {
   const history = useHistory();
@@ -54,12 +55,6 @@ const PleasureCraftForm = ({ source, type }) => {
     const fieldValue = e.target.source === 'CountrySelector' ? e.target.countryName : e.target.value;
     setFormData({ ...formData, [e.target.name]: fieldValue });
     setErrors(removeError(e.target.name, errors));
-  };
-
-  const handleErrorClick = (e, id) => {
-    e.preventDefault();
-    const scrollToError = document.getElementById(id);
-    scrollToError.scrollIntoView();
   };
 
   const validateForm = async () => {
@@ -182,26 +177,9 @@ const PleasureCraftForm = ({ source, type }) => {
               {formPageIs === 1
                 && (
                   <>
+                    <ErrorSummary errors={errors} />
                     <h1 className="govuk-heading-l">{title}</h1>
                     <form autoComplete="off">
-                      {Object.keys(errors).length >= 1 && (
-                      <div className="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabIndex="-1" data-module="govuk-error-summary">
-                        <h2 className="govuk-error-summary__title">
-                          There is a problem
-                        </h2>
-                        <div className="govuk-error-summary__body">
-                          <ul className="govuk-list govuk-error-summary__list">
-                            {Object.entries(errors).reverse().map((elem) => (
-                              <li key={elem[0]}>
-                                {elem[0] !== 'title'
-                            //  eslint-disable-next-line jsx-a11y/anchor-is-valid
-                            && <a onClick={(e) => handleErrorClick(e, elem[0])} href="#">{elem[1]}</a>}
-                              </li>
-                            ))}
-                          </ul>
-                        </div>
-                      </div>
-                      )}
                       <div id="pleasureCraftName" className={`govuk-form-group ${errors.pleasureCraftName ? 'govuk-form-group--error' : ''}`}>
                         <label className="govuk-label" htmlFor="pleasureCraftNameInput">
                           Name of pleasure craft
@@ -229,13 +207,13 @@ const PleasureCraftForm = ({ source, type }) => {
                               <input
                                 className="govuk-radios__input"
                                 name="type"
-                                id="sailingboat"
+                                id="typeInput"
                                 type="radio"
                                 value={SAILINGBOAT_TEXT}
                                 checked={formData.type === SAILINGBOAT_TEXT ? 'checked' : ''}
                                 onChange={handleChange}
                               />
-                              <label className="govuk-label govuk-radios__label" htmlFor="sailingboat">
+                              <label className="govuk-label govuk-radios__label" htmlFor="typeInput">
                                 Sailing boat (with or without an engine)
                               </label>
                             </div>
@@ -268,18 +246,18 @@ const PleasureCraftForm = ({ source, type }) => {
                               </label>
                             </div>
                             {typeOther && (
-                            <div className="govuk-form-group">
-                              <label className="govuk-label" htmlFor="type-other">
-                                Please specify
-                                <input
-                                  className="govuk-input"
-                                  name="type"
-                                  type="text"
-                                  value={typeOther ? formData.type : ''}
-                                  onChange={handleChange}
-                                />
-                              </label>
-                            </div>
+                              <div className="govuk-form-group">
+                                <label className="govuk-label" htmlFor="type-other">
+                                  Please specify
+                                  <input
+                                    className="govuk-input"
+                                    name="type"
+                                    type="text"
+                                    value={typeOther ? formData.type : ''}
+                                    onChange={handleChange}
+                                  />
+                                </label>
+                              </div>
                             )}
                           </div>
                         </fieldset>
@@ -311,13 +289,13 @@ const PleasureCraftForm = ({ source, type }) => {
                           Continue
                         </button>
                         {type === 'edit' && (
-                        <button
-                          type="button"
-                          className="govuk-button govuk-button--warning"
-                          onClick={(e) => { goToNextPage(e, { url: `/pleasure-crafts/${pleasureCraftId}/delete`, runValidation: false }); }}
-                        >
-                          Delete this pleasure craft
-                        </button>
+                          <button
+                            type="button"
+                            className="govuk-button govuk-button--warning"
+                            onClick={(e) => { goToNextPage(e, { url: `/pleasure-crafts/${pleasureCraftId}/delete`, runValidation: false }); }}
+                          >
+                            Delete this pleasure craft
+                          </button>
                         )}
                       </div>
                       <button
@@ -331,101 +309,82 @@ const PleasureCraftForm = ({ source, type }) => {
                   </>
                 )}
               {formPageIs === 2
-              && (
-                <>
-                  <h1 className="govuk-heading-l">Pleasure craft details</h1>
-                  <form autoComplete="off">
-                    {Object.keys(errors).length >= 1 && (
-                    <div className="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabIndex="-1" data-module="govuk-error-summary">
-                      <h2 className="govuk-error-summary__title">
-                        There is a problem
-                      </h2>
-                      <div className="govuk-error-summary__body">
-                        <ul className="govuk-list govuk-error-summary__list">
-                          {Object.entries(errors).reverse().map((elem) => (
-                            <li key={elem[0]}>
-                              {(elem[0] !== 'title' && elem[0] !== 'helpError')
-                            //  eslint-disable-next-line jsx-a11y/anchor-is-valid
-                            && <a onClick={(e) => handleErrorClick(e, elem[0])} href="#">{elem[1]}</a>}
-                              {elem[0] === 'helpError'
-                            && <a href="/page/help">{elem[1]}</a>}
-                            </li>
-                          ))}
-                        </ul>
+                && (
+                  <>
+                    <ErrorSummary errors={errors} />
+                    <h1 className="govuk-heading-l">Pleasure craft details</h1>
+                    <form autoComplete="off">
+                      <div id="registrationNumber" className={`govuk-form-group ${errors.registrationNumber ? 'govuk-form-group--error' : ''}`}>
+                        <label className="govuk-label" htmlFor="registrationNumberInput">
+                          Registration number
+                        </label>
+                        <FormFieldError error={errors.registrationNumber} />
+                        <input
+                          id="registrationNumberInput"
+                          className="govuk-input"
+                          name="registrationNumber"
+                          type="text"
+                          value={formData?.registrationNumber || ''}
+                          onChange={handleChange}
+                        />
                       </div>
-                    </div>
-                    )}
-                    <div id="registrationNumber" className={`govuk-form-group ${errors.registrationNumber ? 'govuk-form-group--error' : ''}`}>
-                      <label className="govuk-label" htmlFor="registrationNumberInput">
-                        Registration number
-                      </label>
-                      <FormFieldError error={errors.registrationNumber} />
-                      <input
-                        id="registrationNumberInput"
-                        className="govuk-input"
-                        name="registrationNumber"
-                        type="text"
-                        value={formData?.registrationNumber || ''}
-                        onChange={handleChange}
-                      />
-                    </div>
 
-                    <div id="registrationCountry" className={`govuk-form-group ${errors.registrationCountry ? 'govuk-form-group--error' : ''}`}>
-                      <fieldset className="govuk-fieldset">
-                        <legend className="govuk-fieldset__legend">
-                          <label className="govuk-fieldset__heading" htmlFor="registrationCountry">
-                            Does this pleasure craft have a Country of Registration?
-                          </label>
-                        </legend>
-                        <div className="govuk-radios govuk-radios">
-                          <FormFieldError error={errors.registrationCountry} />
-                          <div className="govuk-radios__item">
-                            <input
-                              className="govuk-radios__input"
-                              name="registrationCountry"
-                              id="registrationCountryYes"
-                              type="radio"
-                              value="registrationCountryYes"
-                              checked={formData.registrationCountry === 'registrationCountryYes' ? 'checked' : ''}
-                              onChange={handleChange}
-                              data-testid="registrationCountryYes"
-                            />
-                            <label className="govuk-label govuk-radios__label" htmlFor="registrationCountryYes">
-                              Yes
+                      <div id="registrationCountry" className={`govuk-form-group ${errors.registrationCountry ? 'govuk-form-group--error' : ''}`}>
+                        <fieldset className="govuk-fieldset">
+                          <legend className="govuk-fieldset__legend">
+                            <label className="govuk-fieldset__heading" htmlFor="registrationCountry">
+                              Does this pleasure craft have a Country of Registration?
                             </label>
-                          </div>
-                          {registrationCountryYes && (
-                          <div className="govuk-form-group">
-                            <label className="govuk-label" htmlFor="registrationCountryName">
-                              Country of registration
-                              <CountrySelector
-                                defaultValue={registrationCountryYes ? formData.registrationCountryName : ''}
-                                fieldName="registrationCountryName"
-                                onConfirm={(response) => { handleChange(response); }}
+                          </legend>
+                          <div className="govuk-radios govuk-radios">
+                            <FormFieldError error={errors.registrationCountry} />
+                            <div className="govuk-radios__item">
+                              <input
+                                className="govuk-radios__input"
+                                name="registrationCountry"
+                                id="registrationCountryInput"
+                                type="radio"
+                                value="registrationCountryYes"
+                                checked={formData.registrationCountry === 'registrationCountryYes' ? 'checked' : ''}
+                                onChange={handleChange}
+                                data-testid="registrationCountryYes"
                               />
-                            </label>
+                              <label className="govuk-label govuk-radios__label" htmlFor="registrationCountryInput">
+                                Yes
+                              </label>
+                            </div>
+                            {registrationCountryYes && (
+                              <div className="govuk-form-group">
+                                <label className="govuk-label" htmlFor="registrationCountryName">
+                                  Country of registration
+                                  <CountrySelector
+                                    defaultValue={registrationCountryYes ? formData.registrationCountryName : ''}
+                                    fieldName="registrationCountryName"
+                                    onConfirm={(response) => { handleChange(response); }}
+                                  />
+                                </label>
+                              </div>
+                            )}
+                            <div className="govuk-radios__item">
+                              <input
+                                className="govuk-radios__input"
+                                name="registrationCountry"
+                                id="registrationCountryNo"
+                                type="radio"
+                                value="registrationCountryNo"
+                                checked={formData.registrationCountry === 'registrationCountryNo' ? 'checked' : ''}
+                                onChange={handleChange}
+                                data-testid="registrationCountryNo"
+                              />
+                              <label className="govuk-label govuk-radios__label" htmlFor="registrationCountryNo">
+                                No
+                              </label>
+                            </div>
                           </div>
-                          )}
-                          <div className="govuk-radios__item">
-                            <input
-                              className="govuk-radios__input"
-                              name="registrationCountry"
-                              id="registrationCountryNo"
-                              type="radio"
-                              value="registrationCountryNo"
-                              checked={formData.registrationCountry === 'registrationCountryNo' ? 'checked' : ''}
-                              onChange={handleChange}
-                              data-testid="registrationCountryNo"
-                            />
-                            <label className="govuk-label govuk-radios__label" htmlFor="registrationCountryNo">
-                              No
-                            </label>
-                          </div>
-                        </div>
-                      </fieldset>
-                    </div>
+                        </fieldset>
+                      </div>
 
-                    {/* // Waiting on API update:
+                      {/* // Waiting on API update:
                   <div id="pleasureCraftAIS" className={`govuk-form-group ${errors.pleasureCraftAIS ? 'govuk-form-group--error' : ''}`}>
                     <fieldset className="govuk-fieldset">
                       <legend className="govuk-fieldset__legend">
@@ -467,7 +426,7 @@ const PleasureCraftForm = ({ source, type }) => {
                     </fieldset>
                   </div> */}
 
-                    {/* // Waiting on API update:
+                      {/* // Waiting on API update:
                   <div id="pleasureCraftMMSI" className={`govuk-form-group ${errors.pleasureCraftMMSI ? 'govuk-form-group--error' : ''}`}>
                     <fieldset className="govuk-fieldset">
                       <legend className="govuk-fieldset__legend">
@@ -523,93 +482,93 @@ const PleasureCraftForm = ({ source, type }) => {
                     </fieldset>
                   </div> */}
 
-                    <div id="callSign" className={`govuk-form-group ${errors.callSign ? 'govuk-form-group--error' : ''}`}>
-                      <fieldset className="govuk-fieldset">
-                        <legend className="govuk-fieldset__legend">
-                          <label className="govuk-fieldset__heading" htmlFor="callSign">
-                            Does this pleasure craft have a Call sign?
-                          </label>
-                        </legend>
-                        <div className="govuk-radios govuk-radios">
-                          <FormFieldError error={errors.callSign} />
-                          <div className="govuk-radios__item">
-                            <input
-                              className="govuk-radios__input"
-                              name="callSign"
-                              id="callSignYes"
-                              type="radio"
-                              value="callSignYes"
-                              checked={formData.callSign === 'callSignYes' ? 'checked' : ''}
-                              onChange={handleChange}
-                              data-testid="callSignYes"
-                            />
-                            <label className="govuk-label govuk-radios__label" htmlFor="callSignYes">
-                              Yes
+                      <div id="callSign" className={`govuk-form-group ${errors.callSign ? 'govuk-form-group--error' : ''}`}>
+                        <fieldset className="govuk-fieldset">
+                          <legend className="govuk-fieldset__legend">
+                            <label className="govuk-fieldset__heading" htmlFor="callSign">
+                              Does this pleasure craft have a Call sign?
                             </label>
-                          </div>
-                          {callSignYes && (
-                          <div className="govuk-form-group">
-                            <label className="govuk-label" htmlFor="callSignReference">
-                              Call sign
+                          </legend>
+                          <div className="govuk-radios govuk-radios">
+                            <FormFieldError error={errors.callSign} />
+                            <div className="govuk-radios__item">
                               <input
-                                className="govuk-input"
-                                id="callSignReference"
-                                name="callSignReference"
-                                type="text"
-                                defaultValue={formData.callSignReference}
+                                className="govuk-radios__input"
+                                name="callSign"
+                                id="callSignInput"
+                                type="radio"
+                                value="callSignYes"
+                                checked={formData.callSign === 'callSignYes' ? 'checked' : ''}
+                                onChange={handleChange}
+                                data-testid="callSignYes"
+                              />
+                              <label className="govuk-label govuk-radios__label" htmlFor="callSignInput">
+                                Yes
+                              </label>
+                            </div>
+                            {callSignYes && (
+                              <div className="govuk-form-group">
+                                <label className="govuk-label" htmlFor="callSignReference">
+                                  Call sign
+                                  <input
+                                    className="govuk-input"
+                                    id="callSignReference"
+                                    name="callSignReference"
+                                    type="text"
+                                    defaultValue={formData.callSignReference}
+                                    onChange={handleChange}
+                                  />
+                                </label>
+                              </div>
+                            )}
+                            <div className="govuk-radios__item">
+                              <input
+                                className="govuk-radios__input"
+                                name="callSign"
+                                id="callSign-no"
+                                type="radio"
+                                value="callSignNo"
+                                checked={formData.callSign === 'callSignNo' ? 'checked' : ''}
                                 onChange={handleChange}
                               />
-                            </label>
+                              <label className="govuk-label govuk-radios__label" htmlFor="callSign-no">
+                                No
+                              </label>
+                            </div>
                           </div>
-                          )}
-                          <div className="govuk-radios__item">
-                            <input
-                              className="govuk-radios__input"
-                              name="callSign"
-                              id="callSign-no"
-                              type="radio"
-                              value="callSignNo"
-                              checked={formData.callSign === 'callSignNo' ? 'checked' : ''}
-                              onChange={handleChange}
-                            />
-                            <label className="govuk-label govuk-radios__label" htmlFor="callSign-no">
-                              No
-                            </label>
-                          </div>
-                        </div>
-                      </fieldset>
-                    </div>
+                        </fieldset>
+                      </div>
 
-                    <div className="govuk-button-group">
+                      <div className="govuk-button-group">
+                        <button
+                          type="button"
+                          className="govuk-button govuk-button--secondary"
+                          data-module="govuk-button"
+                          onClick={(e) => {
+                            goToNextPage(e, { url: 'previousFormPageIs', runValidation: false });
+                          }}
+                        >
+                          Back
+                        </button>
+                        <button
+                          type="button"
+                          className="govuk-button"
+                          data-module="govuk-button"
+                          onClick={(e) => { handleSubmit(e); }}
+                        >
+                          Save
+                        </button>
+                      </div>
                       <button
                         type="button"
-                        className="govuk-button govuk-button--secondary"
-                        data-module="govuk-button"
-                        onClick={(e) => {
-                          goToNextPage(e, { url: 'previousFormPageIs', runValidation: false });
-                        }}
+                        className="govuk-button govuk-button--text"
+                        onClick={(e) => { goToNextPage(e, { url: sourcePage, runValidation: false }); }}
                       >
-                        Back
+                        Exit without saving
                       </button>
-                      <button
-                        type="button"
-                        className="govuk-button"
-                        data-module="govuk-button"
-                        onClick={(e) => { handleSubmit(e); }}
-                      >
-                        Save
-                      </button>
-                    </div>
-                    <button
-                      type="button"
-                      className="govuk-button govuk-button--text"
-                      onClick={(e) => { goToNextPage(e, { url: sourcePage, runValidation: false }); }}
-                    >
-                      Exit without saving
-                    </button>
-                  </form>
-                </>
-              )}
+                    </form>
+                  </>
+                )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
### AC / Description of changes
Update the new pleasure craft form to use the ErrorSummary component

### To Test
- Go to the pleasure craft tab
- Click the continue button
- All the fields should error
- Click the links in the error summary
- It should scroll to the label and focus on the input
- Fill out the info and continue to the second page
- Click save and all fields should error and the links should work the same as page 1

### Notes
Some radio ids needed to be changed so they could be focused when clicking on the error link

---
* remember to merge to feature branches not master *


